### PR TITLE
JSX & SCSS color adjustments

### DIFF
--- a/src/main/resources/themes/vscode_dark.xml
+++ b/src/main/resources/themes/vscode_dark.xml
@@ -1001,6 +1001,7 @@
                 <option name="FOREGROUND" value="4ec9b0"/>
             </value>
         </option>
+        <option name="SASS_COMMENT" baseAttributes="CSS.COMMENT"/>
         <option name="SEARCH_RESULT_ATTRIBUTES">
             <value>
                 <option name="FOREGROUND" value="dcdcaa"/>

--- a/src/main/resources/themes/vscode_dark.xml
+++ b/src/main/resources/themes/vscode_dark.xml
@@ -523,6 +523,11 @@
                 <option name="FOREGROUND" value="569cd6"/>
             </value>
         </option>
+        <option name="HTML_CUSTOM_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="40c8ae"/>
+            </value>
+        </option>
         <option name="HYPERLINK_ATTRIBUTES">
             <value>
                 <option name="FOREGROUND" value="569cd6"/>
@@ -1120,6 +1125,11 @@
                 <option name="FOREGROUND" value="d4d4d4"/>
                 <option name="BACKGROUND" value="1e1e1e"/>
                 <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="XML_CUSTOM_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="40c8ae"/>
             </value>
         </option>
         <option name="XML_TAG_DATA" baseAttributes="TEXT"/>


### PR DESCRIPTION
According to [this](https://youtrack.jetbrains.com/issue/WEB-21035/add-JSX-options-to-colors-and-fonts-syntax-coloring) issue, we can highlight React components in JSX with different colors, like in VS Code. JSX is XML from IDEA's point of view. So I make this small adjustment.

I also fixed SCSS comments color, so it inherits from CSS comments now.

P.S. I took colors from Microsoft's [VS Code Toolkit](https://www.figma.com/community/file/786632241522687494).

| PhpStorm before | PhpStorm after | VS Code |
| ------------------ | ---------------- | --------- |
| ![image](https://user-images.githubusercontent.com/9428948/177686390-f744cd29-2313-49b3-b664-7c8d685898b9.png) | ![image](https://user-images.githubusercontent.com/9428948/177686548-d40c3ec1-8839-4db3-8a43-d4371e29ec50.png) | ![image](https://user-images.githubusercontent.com/9428948/177686998-17801785-e5c9-4ec6-aeb9-e089bfc36526.png) |


