### PR TITLE
Feature - #55 fixing Syntax highlighting for shell scripts Themes

### DIFF
--- a/src/main/resources/themes/vscode_dark.xml
+++ b/src/main/resources/themes/vscode_dark.xml
@@ -51,11 +51,6 @@
             </value>
         </option>
         <option name="BASH.SHEBANG" baseAttributes="BASH.LINE_COMMENT"/>
-        <option name="BASH.VAR_DEF">
-            <value>
-                <option name="FOREGROUND" value="d3d3c8"/>
-            </value>
-        </option>
         <option name="BASH.VAR_USE">
             <value>
                 <option name="FOREGROUND" value="9cdcfe"/>

--- a/src/main/resources/themes/vscode_dark_brighter.xml
+++ b/src/main/resources/themes/vscode_dark_brighter.xml
@@ -51,11 +51,6 @@
             </value>
         </option>
         <option name="BASH.SHEBANG" baseAttributes="BASH.LINE_COMMENT"/>
-        <option name="BASH.VAR_DEF">
-            <value>
-                <option name="FOREGROUND" value="d3d3c8"/>
-            </value>
-        </option>
         <option name="BASH.VAR_USE">
             <value>
                 <option name="FOREGROUND" value="8cd7ff"/>


### PR DESCRIPTION
Part 2 - FIxing Variable color in themes.

![image](https://user-images.githubusercontent.com/17984781/236651223-15ba498b-c233-4a71-893c-a0d5f7baf169.png)
