### PR TITLE
Changed instance field color

### DIFF
--- a/src/main/resources/themes/vscode_dark_brighter.xml
+++ b/src/main/resources/themes/vscode_dark_brighter.xml
@@ -20,7 +20,7 @@
     <attributes>
         <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="ANNOTATION_NAME_ATTRIBUTES" baseAttributes="DEFAULT_METADATA"/>
@@ -53,7 +53,7 @@
         <option name="BASH.SHEBANG" baseAttributes="BASH.LINE_COMMENT"/>
         <option name="BASH.VAR_USE">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="CMD_EXPRESSION">
@@ -302,7 +302,7 @@
         </option>
         <option name="DEFAULT_INSTANCE_FIELD">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="DEFAULT_INTERFACE_NAME">
@@ -349,7 +349,7 @@
         </option>
         <option name="DEFAULT_REASSIGNED_LOCAL_VARIABLE">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
                 <option name="EFFECT_COLOR" value="707d95"/>
                 <option name="EFFECT_TYPE" value="1"/>
             </value>
@@ -476,12 +476,12 @@
         <option name="GO_PACKAGE" baseAttributes="DEFAULT_IDENTIFIER"/>
         <option name="GO_PACKAGE_EXPORTED_CONSTANT">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="GO_PACKAGE_LOCAL_CONSTANT">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="GO_SHADOWING_VARIABLE" baseAttributes="DEFAULT_LOCAL_VARIABLE"/>
@@ -552,7 +552,7 @@
         </option>
         <option name="INSTANCE_FIELD_ATTRIBUTES">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="INSTANCE_FINAL_FIELD_ATTRIBUTES">
@@ -616,7 +616,7 @@
         </option>
         <option name="JS.PARAMETER">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="JS.SECONDARY_KEYWORDS">
@@ -1092,17 +1092,17 @@
         </option>
         <option name="SWIFT_PROPERTY">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="SWIFT_TUPLE_LABEL">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="SWIFT_WILDCARD">
             <value>
-                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="FOREGROUND" value="00ffff"/>
             </value>
         </option>
         <option name="Static method access" baseAttributes="STATIC_METHOD_ATTRIBUTES"/>


### PR DESCRIPTION
Right now the highlight for fields and local variables is the same:

![изображение](https://github.com/dinbtechit/vscode-theme/assets/70556725/0cb10481-2ced-4df4-a462-f6c21fae4c89)

I suggest adding different highlighting:

![изображение](https://github.com/dinbtechit/vscode-theme/assets/70556725/3b78c351-ef14-4418-b575-e24a2e2e0eb5)

I am not sure about color though