### PR TITLE
Fix - #71 initial - fixing inconsistent python highlighting.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # vscode-theme Changelog
 
 ## Unreleased
+### Fixed
+- #71 - Python - Inconsistent - Import and variables colors (initial)
 
 ## 1.8.1 - 2023-06-25
 - #67 - Fix inactive selection color in Dark Modern theme

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = com.github.dinbtechit.vscodetheme
 pluginName = VSCode Theme
 # SemVer format -> https://semver.org
-pluginVersion = 1.8.1
+pluginVersion = 1.8.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 211

--- a/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/PyAnnotator.kt
+++ b/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/PyAnnotator.kt
@@ -3,10 +3,17 @@ package com.github.dinbtechit.vscodetheme.annotators
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiTypeElement
-import com.intellij.psi.util.contextOfType
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.intellij.util.ObjectUtils
+import com.jetbrains.python.psi.*
+import com.jetbrains.python.psi.impl.PyImportedModule
+import com.jetbrains.python.psi.impl.references.PyImportReference
+import com.jetbrains.python.psi.impl.stubs.PyClassElementType
+import com.jetbrains.python.psi.types.PyClassType
+import com.jetbrains.python.psi.types.PyType
+import com.jetbrains.python.psi.types.TypeEvalContext
+
 
 class PyAnnotator : BaseAnnotator() {
     companion object {
@@ -22,15 +29,56 @@ class PyAnnotator : BaseAnnotator() {
             "PY.SECONDARY_KEYWORD_WITH_BG",
             DEFAULT_KEYWORD
         )
+
+        val FUNCTION_WITH_BG: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+            "PY.FUNCTION_CALL",
+            DefaultLanguageHighlighterColors.FUNCTION_CALL
+        )
+
+        val CLASS_REFERENCE_WITH_BG: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+            "PY.CLASS_REFERENCE",
+            DefaultLanguageHighlighterColors.CLASS_REFERENCE
+        )
     }
 
     override fun getKeywordType(element: PsiElement): TextAttributesKey? {
         var type: TextAttributesKey? = null
+
+        if ((element.elementType is PyElementType
+                    && (element.parent is PyTargetExpression || element.parent is PyReferenceExpression)) && (element.parent !is PyFunction)
+        ) {
+            type = DefaultLanguageHighlighterColors.LOCAL_VARIABLE
+        }
+
+        if ((element.parent is PyClass && element.nextSibling is PyArgumentList)
+            || element.parent.reference?.resolve().elementType is PyClassElementType
+        ) {
+            type = CLASS_REFERENCE_WITH_BG
+        }
+
+        if ((element.parent is PyFunction && element.text != "def")
+            || (element.parent.reference?.resolve() is PyFunction && element.text != "def")
+        ) {
+            type = FUNCTION_WITH_BG
+        }
+
+        if (element.parent is PyStringLiteralExpression) {
+            type = DefaultLanguageHighlighterColors.STRING
+        }
+
+        if (element.parent.reference is PyImportReference
+            || element.parent.reference?.resolve() is PyImportedModule
+            || element.parent.reference?.resolve() is PyFile) {
+            type = CLASS_REFERENCE_WITH_BG
+        }
+
         when (element.text) {
             "import", "as", "in",
             "continue", "del", "assert", "break", "finally", "for", "from",
             "elif", "else", "if", "except", "pass", "raise", "return", "try", "while",
             "with" -> type = SECONDARY_KEYWORD
+
+            "self" -> type = DEFAULT_KEYWORD
             "async", "await" -> type = SECONDARY_KEYWORD_WITH_BG
             else -> {}
         }

--- a/src/main/resources/themes/vscode_dark.xml
+++ b/src/main/resources/themes/vscode_dark.xml
@@ -974,10 +974,22 @@
                 <option name="FOREGROUND" value="4ec9b0"/>
             </value>
         </option>
-        <option name="PY.DECORATOR">
+        <option name="PY.CLASS_REFERENCE">
             <value>
                 <option name="FOREGROUND" value="4ec9b0"/>
+                <option name="BACKGROUND" value="1e1e1e"/>
+            </value>
+        </option>
+        <option name="PY.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
                 <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="PY.FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="dbdbaa"/>
+                <option name="BACKGROUND" value="1e1e1e"/>
             </value>
         </option>
         <option name="PY.KEYWORD_ARGUMENT">

--- a/src/main/resources/themes/vscode_dark_brighter.xml
+++ b/src/main/resources/themes/vscode_dark_brighter.xml
@@ -974,10 +974,22 @@
                 <option name="FOREGROUND" value="47ccb1"/>
             </value>
         </option>
+        <option name="PY.CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+                <option name="BACKGROUND" value="1e1e1e"/>
+            </value>
+        </option>
         <option name="PY.DECORATOR">
             <value>
                 <option name="FOREGROUND" value="47ccb1"/>
                 <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="PY.FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+                <option name="BACKGROUND" value="1e1e1e"/>
             </value>
         </option>
         <option name="PY.KEYWORD_ARGUMENT">


### PR DESCRIPTION
Initial take on fixing inconsistent python highlighting.

## Before:
![image](https://github.com/dinbtechit/vscode-theme/assets/17984781/191e7f79-4ca2-44ee-8c6f-92cae57cff05)


## After:
![image](https://github.com/dinbtechit/vscode-theme/assets/17984781/441364fb-3bc9-4993-a870-08be03340dd7)

