### PR TITLE
Fix #77 #79  [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # vscode-theme Changelog
 
 ## Unreleased
+### Fixed
+- #77 - Pycharm Community edition - Inconsistent colors
+- #79 - Adding separate color settings for Python imports 
 
 ## 1.8.3 - 2023-06-29
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = com.github.dinbtechit.vscodetheme
 pluginName = VSCode Theme
 # SemVer format -> https://semver.org
-pluginVersion = 1.8.3
+pluginVersion = 1.8.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 211
@@ -16,7 +16,7 @@ platformVersion = 2023.1.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins = JavaScript, com.intellij.java, io.flutter:73.1.1, Dart:231.9065, PsiViewer:231-SNAPSHOT, \
-Pythonid:231.8770.65, org.jetbrains.kotlin, com.jetbrains.php:231.8770.68, org.jetbrains.plugins.go:231.8770.53, \
+Pythonid:231.8770.65, PythonCore:231.8770.65, org.jetbrains.kotlin, com.jetbrains.php:231.8770.68, org.jetbrains.plugins.go:231.8770.53, \
 org.rust.lang:0.4.194.5382-231,com.jetbrains.sh
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases

--- a/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/PyAnnotator.kt
+++ b/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/PyAnnotator.kt
@@ -35,6 +35,11 @@ class PyAnnotator : BaseAnnotator() {
             "PY.CLASS_REFERENCE",
             DefaultLanguageHighlighterColors.CLASS_REFERENCE
         )
+
+        val IMPORT_REFERENCE_WITH_BG: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+            "PY.CLASS_REFERENCE",
+            DefaultLanguageHighlighterColors.CLASS_REFERENCE
+        )
     }
 
     override fun getKeywordType(element: PsiElement): TextAttributesKey? {
@@ -62,7 +67,7 @@ class PyAnnotator : BaseAnnotator() {
         if (element.parent.reference is PyImportReference
             || element.parent.reference?.resolve() is PyImportedModule
             || element.parent.reference?.resolve() is PyFile) {
-            type = CLASS_REFERENCE_WITH_BG
+            type = IMPORT_REFERENCE_WITH_BG
         }
 
 

--- a/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/settings/PyColorSettingsPage.kt
+++ b/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/settings/PyColorSettingsPage.kt
@@ -41,7 +41,7 @@ class PyColorSettingsPage : PythonColorsPage() {
         <secondaryKeyword>import</secondaryKeyword> <importReference>string</importReference>
          
         @<decorator>app</decorator>.<nestedFuncDef>get</nestedFuncDef>("/hello/somename")
-        <secondaryKeywordBg>async</secondaryKeywordBg> def <nestedFuncDef>say_bye</nestedFuncDef>(name: bool):
+        <secondaryKeywordBg>async</secondaryKeywordBg> def <nestedFuncDef>say_bye</nestedFuncDef>(<kwarg>name</kwarg>: <classDef>bool</classDef>):
             <secondaryKeyword>return</secondaryKeyword> {"message": f"bye {<kwarg>name</kwarg>}"}
 
 

--- a/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/settings/PyColorSettingsPage.kt
+++ b/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/settings/PyColorSettingsPage.kt
@@ -11,8 +11,9 @@ import java.util.*
 class PyColorSettingsPage : PythonColorsPage() {
     companion object {
         private val ATTRIBUTES: Array<AttributesDescriptor?> = arrayOf(
-            AttributesDescriptor("SecondaryKeywords", PyAnnotator.SECONDARY_KEYWORD),
-            AttributesDescriptor("SecondaryKeywordsBg", PyAnnotator.SECONDARY_KEYWORD_WITH_BG),
+            AttributesDescriptor("Secondary keywords", PyAnnotator.SECONDARY_KEYWORD),
+            AttributesDescriptor("Secondary keywords with Bg", PyAnnotator.SECONDARY_KEYWORD_WITH_BG),
+            AttributesDescriptor("Import reference with Bg", PyAnnotator.IMPORT_REFERENCE_WITH_BG),
         )
         val DESCRIPTORS = mutableMapOf<String, TextAttributesKey>()
     }
@@ -25,6 +26,7 @@ class PyColorSettingsPage : PythonColorsPage() {
         val descriptors: MutableMap<String, TextAttributesKey> = HashMap()
         descriptors["secondaryKeyword"] = PyAnnotator.SECONDARY_KEYWORD
         descriptors["secondaryKeywordBg"] = PyAnnotator.SECONDARY_KEYWORD_WITH_BG
+        descriptors["importReference"] = PyAnnotator.IMPORT_REFERENCE_WITH_BG
         return descriptors
     }
 
@@ -34,18 +36,19 @@ class PyColorSettingsPage : PythonColorsPage() {
 
     override fun getDemoText(): String {
         return """
-        <secondaryKeyword>from</secondaryKeyword> flask <secondaryKeyword>import</secondaryKeyword> work 
-        <secondaryKeyword>import</secondaryKeyword> string
+        <secondaryKeyword>from</secondaryKeyword> <importReference>flask</importReference> <secondaryKeyword>import</secondaryKeyword> <importReference>work</importReference> 
+        <secondaryKeyword>from</secondaryKeyword> <importReference>Something</importReference>, <importReference>Something2</importReference> <secondaryKeyword>import</secondaryKeyword> <importReference>work</importReference>  
+        <secondaryKeyword>import</secondaryKeyword> <importReference>string</importReference>
          
-        @app.get("/hello/somename")
-        <secondaryKeywordBg>async</secondaryKeywordBg> def say_bye(name: bool):
-            <secondaryKeyword>return</secondaryKeyword> {"message": f"bye {name}"}
+        @<decorator>app</decorator>.<nestedFuncDef>get</nestedFuncDef>("/hello/somename")
+        <secondaryKeywordBg>async</secondaryKeywordBg> def <nestedFuncDef>say_bye</nestedFuncDef>(name: bool):
+            <secondaryKeyword>return</secondaryKeyword> {"message": f"bye {<kwarg>name</kwarg>}"}
 
 
-        @app.get("/hello/{name}")
-        <secondaryKeywordBg>async</secondaryKeywordBg> def say_hello(name: bool):
-            <secondaryKeywordBg>await</secondaryKeywordBg> say_bye(name)
-            <secondaryKeyword>return</secondaryKeyword> {"message": f"Hello {name}"}
+        @<decorator>app</decorator>.<nestedFuncDef>get</nestedFuncDef>("/hello/{name}")
+        <secondaryKeywordBg>async</secondaryKeywordBg> def <nestedFuncDef>say_hello</nestedFuncDef>(<kwarg>name</kwarg>: bool):
+            <secondaryKeywordBg>await</secondaryKeywordBg> <nestedFuncDef>say_bye</nestedFuncDef>(<kwarg>name</kwarg>)
+            <secondaryKeyword>return</secondaryKeyword> {"message": f"Hello {<kwarg>name</kwarg>}"}
 
         """.trimIndent() + super.getDemoText()
     }

--- a/src/main/resources/META-INF/lang-config/dinbtechit-python-community.xml
+++ b/src/main/resources/META-INF/lang-config/dinbtechit-python-community.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <annotator language="Python" order="last"
+                   implementationClass="com.github.dinbtechit.vscodetheme.annotators.PyAnnotator"/>
+        <colorSettingsPage order="last" implementation="com.github.dinbtechit.vscodetheme.annotators.settings.PyColorSettingsPage"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,8 @@
     <depends config-file="lang-config/dinbtechit-javascript.xml" optional="true">JavaScript</depends>
     <depends config-file="lang-config/dinbtechit-java.xml" optional="true">com.intellij.java</depends>
     <depends config-file="lang-config/dinbtechit-dart.xml" optional="true">Dart</depends>
-    <depends config-file="lang-config/dinbtechit-python.xml" optional="true">Pythonid</depends>
+    <depends config-file="lang-config/dinbtechit-python.xml" optional="true">PythonCore</depends>
+    <depends config-file="lang-config/dinbtechit-python-community.xml" optional="true">Pythonid</depends>
     <depends config-file="lang-config/dinbtechit-kotlin.xml" optional="true">org.jetbrains.kotlin</depends>
     <depends config-file="lang-config/dinbtechit-csharp.xml" optional="true">com.intellij.modules.rider</depends>
     <depends config-file="lang-config/dinbtechit-php.xml" optional="true">com.jetbrains.php</depends>

--- a/src/main/resources/themes/vscode_dark.xml
+++ b/src/main/resources/themes/vscode_dark.xml
@@ -988,7 +988,13 @@
         </option>
         <option name="PY.DOC_COMMENT">
             <value>
-                <option name="FOREGROUND" value="cd9069"/>
+                <option name="FOREGROUND" value="4ec9b0"/>
+                <option name="BACKGROUND" value="1e1e1e"/>
+            </value>
+        </option>
+        <option name="PY.IMPORTS">
+            <value>
+                <option name="FOREGROUND" value="47CCB1"/>
             </value>
         </option>
         <option name="PY.FUNCTION_CALL">

--- a/src/main/resources/themes/vscode_dark_brighter.xml
+++ b/src/main/resources/themes/vscode_dark_brighter.xml
@@ -991,6 +991,12 @@
                 <option name="FOREGROUND" value="cd9069"/>
             </value>
         </option>
+        <option name="PY.IMPORTS">
+            <value>
+                <option name="FOREGROUND" value="47CCB1"/>
+                <option name="BACKGROUND" value="1e1e1e"/>
+            </value>
+        </option>
         <option name="PY.FUNCTION_CALL">
             <value>
                 <option name="FOREGROUND" value="e6e6aa"/>


### PR DESCRIPTION
### Fixes

- #77 - Pycharm Community edition - Inconsistent colors
![image](https://github.com/dinbtechit/vscode-theme/assets/17984781/a38b85c4-5864-4b8b-84d3-54603f28415c)

- #79 - Adding separate color settings for Python imports 
![image](https://github.com/dinbtechit/vscode-theme/assets/17984781/0bc29f0c-20d3-448f-86bb-9ad136ebb784)

