### PR TITLE
Feature/84 report bug right from ide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 # vscode-theme Changelog
 
 ## Unreleased
+### Added
+- Rainbow Brackets plugin will now be bundled within VSCode theme
+- #84 - Functionality to report bug through IDE error reporting tool
+
+### Fixed
+- Icon colors are messed up in VSCode light theme
+
 
 ## 1.9.1 - 2023-08-13
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ platformVersion = 2023.1.1
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins = JavaScript, com.intellij.java, io.flutter:73.1.1, Dart:231.9065, PsiViewer:231-SNAPSHOT, \
 Pythonid:231.8770.65, PythonCore:231.8770.65, org.jetbrains.kotlin, com.jetbrains.php:231.8770.68, org.jetbrains.plugins.go:231.8770.53, \
-org.rust.lang:0.4.194.5382-231,com.jetbrains.sh
+org.rust.lang:0.4.194.5382-231,com.jetbrains.sh,izhangzhihao.rainbow.brackets.lite:1.0.1
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = com.github.dinbtechit.vscodetheme
 pluginName = VSCode Theme
 # SemVer format -> https://semver.org
-pluginVersion = 1.9.1
+pluginVersion = 1.10.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 211

--- a/src/main/kotlin/com/github/dinbtechit/vscodetheme/diagostic/VSCodeErrorReportSubmitter.kt
+++ b/src/main/kotlin/com/github/dinbtechit/vscodetheme/diagostic/VSCodeErrorReportSubmitter.kt
@@ -1,0 +1,130 @@
+package com.github.dinbtechit.vscodetheme.diagostic
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.openapi.diagnostic.SubmittedReportInfo
+import com.intellij.openapi.extensions.PluginId
+import org.apache.commons.lang.StringUtils
+import org.apache.http.client.utils.URIBuilder
+import java.awt.Component
+import java.io.BufferedReader
+import java.io.StringReader
+import java.net.URI
+import java.util.stream.Collectors
+
+class VSCodeErrorReportSubmitter: ErrorReportSubmitter() {
+
+    private val packageAbbreviation: Map<String, String>? = null
+
+    override fun getReportActionText(): String {
+        return "Report to VSCode Theme"
+    }
+
+    override fun submit(
+        events: Array<out IdeaLoggingEvent>,
+        additionalInfo: String?,
+        parentComponent: Component,
+        consumer: com.intellij.util.Consumer<in SubmittedReportInfo>
+    ): Boolean {
+        getReportIssueUrl(
+            getReportTitle(events),
+            getReportBody(events, additionalInfo)
+        )?.let {
+            BrowserUtil.browse(it)
+        }
+        return true
+    }
+
+    private fun getReportTitle(events: Array<out IdeaLoggingEvent>): String {
+        val event = events.firstOrNull()
+        return event?.throwableText?.lineSequence()?.first()
+            ?: event?.message
+            ?: "Report bug"
+    }
+
+    private fun getReportBody(events: Array<out IdeaLoggingEvent>, additionalInfo: String?): String {
+        val javaVendor = System.getProperty("java.vendor")
+        val javaVersion = System.getProperty("java.version")
+
+        val osName = System.getProperty("os.name")
+        val osArch = System.getProperty("os.arch")
+
+        val appName = ApplicationInfo.getInstance().fullApplicationName
+
+        val plugin = PluginManagerCore.getPlugin(PluginId.getId("com.github.dinbtechit.vscodetheme"))
+        val pluginVersion = plugin?.version
+
+        var stackTrace = ""
+        for (event in events) {
+            val message = event.message
+            if (!message.isNullOrBlank()) {
+                stackTrace = stackTrace.plus(message).plus("\n")
+            }
+            val throwableText = event.throwableText
+            if (!throwableText.isNullOrBlank()) {
+                stackTrace = stackTrace.plus("\n```\n")
+                stackTrace= stackTrace.plus(
+                    BufferedReader(StringReader(throwableText)).lines()
+                        .map { line ->
+                            var abbreviated = line
+                            packageAbbreviation?.entries?.forEach { entry ->
+                                abbreviated = StringUtils.replace(abbreviated, entry.key, entry.value)
+                            }
+                            abbreviated
+                        }.collect(Collectors.joining("\n"))
+                )
+                stackTrace= stackTrace.plus("\n```\n\n")
+            }
+        }
+        var description = additionalInfo
+        if (description.isNullOrBlank()) {
+            description = "A clear and concise description of what the bug is."
+        }
+
+        return """ 
+            |#Describe the bug
+            | $description
+            |
+            |#To Reproduce
+            |Steps to reproduce the behavior:
+            |1. Go to '...'
+            |2. Click on '....'
+            |3. Scroll down to '....'
+            |4. See error
+            |
+            |#Expected behavior
+            |A clear and concise description of what you expected to happen.
+            |
+            |#Screenshots
+            |If applicable, add screenshots to help explain your problem.
+            |
+            |#Environment
+            |* Java: $javaVendor $javaVersion
+            |* OS: $osName $osArch
+            |* IDE: $appName
+            |* Version: $pluginVersion
+            |
+            |#Additional context
+            |${additionalInfo ?: "Add any other context about the problem here."} 
+            |
+            |#Stacktrace#
+            | $stackTrace
+            """.trimMargin()
+    }
+
+    private fun getReportIssueUrl(title: String, body: String): URI? {
+        val uriBuilder = URIBuilder("https://github.com/dinbtechit/vscode-theme/issues/new")
+        uriBuilder.addParameter("title", "[Bug] $title")
+        uriBuilder.addParameter("labels", "bug")
+        if (body.isNotBlank()) {
+            uriBuilder.addParameter("body", body)
+        } else {
+            uriBuilder.addParameter("template", "bug_report.md")
+        }
+        return uriBuilder.build()
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,7 @@
     <idea-version since-build="213"/>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>izhangzhihao.rainbow.brackets.lite</depends>
 
     <depends config-file="lang-config/dinbtechit-javascript.xml" optional="true">JavaScript</depends>
     <depends config-file="lang-config/dinbtechit-java.xml" optional="true">com.intellij.java</depends>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,7 @@
         <notificationGroup id="VSCode Theme Notification Group" displayType="STICKY_BALLOON"/>
         <!--https://github.com/dinbtechit/vscode-theme/issues/38 Default Annotator Issues-->
         <!--<annotator language="" order="last" implementationClass="com.github.dinbtechit.vscodetheme.annotators.DefaultAnnotator"/>-->
+        <errorHandler implementation="com.github.dinbtechit.vscodetheme.diagostic.VSCodeErrorReportSubmitter"/>
     </extensions>
     <actions>
         <action id="AlwaysApplyThemeAction" class="com.github.dinbtechit.vscodetheme.actions.AlwaysApplyThemeAction"

--- a/src/main/resources/themes/vscode_light.theme.json
+++ b/src/main/resources/themes/vscode_light.theme.json
@@ -8,13 +8,6 @@
       "background": "#F8F8F8"
     },
 
-    "Component": {
-      "errorFocusColor": "#843937",
-      "inactiveErrorFocusColor": "#433239",
-      "warningFocusColor": "#8F7B2E",
-      "inactiveWarningFocusColor": "#434136"
-    },
-
     "Editor": {
       "background": "#FFFFFF"
     },
@@ -23,6 +16,7 @@
       "startBackground": "#f5bc2d",
       "endBackground": "#e9b32b"
     },
+
 
     "ToggleButton": {
       "onBackground": "#1D7BED"


### PR DESCRIPTION
### Added
- Rainbow Brackets plugin will now be bundled within VSCode theme
- #84 - Functionality to report bug through IDE error reporting tool

### Fixed
- Icon colors are messed up in VSCode light theme

