### PR TITLE
Fix for #150 and #151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 # vscode-theme Changelog
 
 ## Unreleased
+### Changed
+- Removed Enum usage as it is not supported in PyCharm, CLion and RubyMine 2022.x.x
+- Upgrading Gradle - `8.1` to `8.3`
+
+### Fixed
+- #130 - VScode startup activity error - Specific to PyCharm, CLion and RubyMine.
+- #132 - Java -Wrong colors if there is extends or super keyword inside generic of generic.
+- #139 - Python Jupyter - Removed black background in Jupyter (Had to make a Temp fix might not be perfect.)
+- VSCode Light Theme - Toolbar background was white and hard to see the buttons.
+- #150 - Unable to select the default theme DARK_MODERN
+- #151 - java.lang.NoClassDefFoundError JupyterPyDialect
 
 ## 1.10.4 - 2023-10-15
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = com.github.dinbtechit.vscodetheme
 pluginName = VSCode Theme
 # SemVer format -> https://semver.org
-pluginVersion = 1.10.4
+pluginVersion = 1.10.5
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/src/main/kotlin/com/github/dinbtechit/vscodetheme/VSCodeThemeManager.kt
+++ b/src/main/kotlin/com/github/dinbtechit/vscodetheme/VSCodeThemeManager.kt
@@ -47,8 +47,9 @@ class VSCodeThemeManager {
     fun switchToVSCodeTheme(always: Boolean = false, selectedVSCodeTheme: String = VSCodeTheme.DARK) {
         try {
             if (isVSCodeThemeReady()) {
+                val convertedSelectedVSCodeTheme = convertOldToNewTheme(selectedVSCodeTheme)
                 val vscodeTheme =
-                    LafManager.getInstance().installedLookAndFeels.first { it.name == selectedVSCodeTheme }
+                    LafManager.getInstance().installedLookAndFeels.first { it.name == convertedSelectedVSCodeTheme }
                 LafManager.getInstance().currentLookAndFeel = vscodeTheme
                 if (always) {
                     val settings = VSCodeThemeSettingsStore.instance
@@ -59,5 +60,14 @@ class VSCodeThemeManager {
         } catch (e: Exception) {
             throw(Error("Unable to select the default theme $selectedVSCodeTheme", e))
         }
+    }
+
+    private fun convertOldToNewTheme(theme: String): String {
+        return when (theme) {
+            "DARK_MODERN" -> "VSCode Dark Modern"
+            "DARK" -> "VSCode Dark"
+            else -> theme
+        }
+
     }
 }

--- a/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/PyAnnotator.kt
+++ b/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/PyAnnotator.kt
@@ -1,6 +1,7 @@
 package com.github.dinbtechit.vscodetheme.annotators
 
 
+import com.intellij.lang.Language
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.psi.PsiElement
@@ -10,7 +11,6 @@ import com.jetbrains.python.psi.*
 import com.jetbrains.python.psi.impl.PyImportedModule
 import com.jetbrains.python.psi.impl.references.PyImportReference
 import com.jetbrains.python.psi.impl.stubs.PyClassElementType
-import org.jetbrains.plugins.notebooks.jupyter.python.JupyterPyDialect
 
 
 class PyAnnotator : BaseAnnotator() {
@@ -110,8 +110,7 @@ class PyAnnotator : BaseAnnotator() {
 
     private fun isJupyterNoteBook(element: PsiElement): Boolean {
          return element.containingFile.name.contains(".ipynb")
-                    || element.containingFile.language.displayName == JupyterPyDialect.displayName
-
+                 || element.containingFile.language == Language.findLanguageByID("JupyterPython")
     }
 
 }

--- a/src/main/resources/themes/vscode_dark.xml
+++ b/src/main/resources/themes/vscode_dark.xml
@@ -18,6 +18,14 @@
         <option name="VISUAL_INDENT_GUIDE" value="3b3b3b"/>
     </colors>
     <attributes>
+        <option name="JUPYTER.CELL_UNDER_CARET_COMMAND_MODE_STRIPE_COLOR" value="FF9800"/>
+        <option name="JUPYTER.CELL_UNDER_CARET_EDITOR_MODE_STRIPE_COLOR" value="3F3F3F"/>
+        <option name="JUPYTER.CODE_CELL_BACKGROUND" value="292929"/>
+        <option name="JUPYTER.GUTTER_INPUT_EXECUTION_COUNT" value="f78c6c"/>
+        <option name="JUPYTER.GUTTER_OUTPUT_EXECUTION_COUNT" value="80cbc4"/>
+        <option name="JUPYTER.PROGRESS_STATUS_RUNNING_COLOR" value="FF9800"/>
+        <option name="JUPYTER.SAUSAGE_BUTTON_BORDER_COLOR" value="292929"/>
+        <option name="JUPYTER.SAUSAGE_BUTTON_SHORTCUT_COLOR" value="727272"/>
         <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
             <value>
                 <option name="FOREGROUND" value="9cdcfe"/>

--- a/src/main/resources/themes/vscode_dark_brighter.xml
+++ b/src/main/resources/themes/vscode_dark_brighter.xml
@@ -18,6 +18,14 @@
         <option name="VISUAL_INDENT_GUIDE" value="3b3b3b"/>
     </colors>
     <attributes>
+        <option name="JUPYTER.CELL_UNDER_CARET_COMMAND_MODE_STRIPE_COLOR" value="FF9800"/>
+        <option name="JUPYTER.CELL_UNDER_CARET_EDITOR_MODE_STRIPE_COLOR" value="3F3F3F"/>
+        <option name="JUPYTER.CODE_CELL_BACKGROUND" value="292929"/>
+        <option name="JUPYTER.GUTTER_INPUT_EXECUTION_COUNT" value="f78c6c"/>
+        <option name="JUPYTER.GUTTER_OUTPUT_EXECUTION_COUNT" value="80cbc4"/>
+        <option name="JUPYTER.PROGRESS_STATUS_RUNNING_COLOR" value="FF9800"/>
+        <option name="JUPYTER.SAUSAGE_BUTTON_BORDER_COLOR" value="292929"/>
+        <option name="JUPYTER.SAUSAGE_BUTTON_SHORTCUT_COLOR" value="727272"/>
         <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
             <value>
                 <option name="FOREGROUND" value="8cd7ff"/>


### PR DESCRIPTION
### Changed
- Removed Enum usage as it is not supported in PyCharm, CLion and RubyMine 2022.x.x
- Upgrading Gradle - `8.1` to `8.3`

### Fixed
- #130 - VScode startup activity error - Specific to PyCharm, CLion and RubyMine.
- #132 - Java -Wrong colors if there is extends or super keyword inside generic of generic.
- #139 - Python Jupyter - Removed black background in Jupyter (Had to make a Temp fix might not be perfect.)
- VSCode Light Theme - Toolbar background was white and hard to see the buttons.
- #150 - Unable to select the default theme DARK_MODERN
- #151 - java.lang.NoClassDefFoundError JupyterPyDialect