### PR TITLE
Fix icon color of RunWidget and background color of RecentProject of new UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Fixed:
+- VScode Light Modern — The icon color of RunWidge is too light to see; by @trofoto
+- VScode Light Modern — The background color of RecentProject is too dark. by @trofoto
+
 ## 1.10.7 - 2023-10-30
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = com.github.dinbtechit.vscodetheme
 pluginName = VSCode Theme
 # SemVer format -> https://semver.org
-pluginVersion = 1.10.7
+pluginVersion = 1.10.8
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/src/main/resources/themes/vscode_light.theme.json
+++ b/src/main/resources/themes/vscode_light.theme.json
@@ -134,6 +134,83 @@
       "SidePanel.background": "#F8F8F8",
       "Projects.background": "#FFFFFF",
       "Projects.actions.background": "#225DA1"
+    },
+
+    "RecentProject": {
+      "Color1": {
+        "MainToolbarGradientStart": "#F5D4C1",
+        "Avatar": {
+          "Start": "#E08855",
+          "End": "#E9806F"
+        }
+      },
+      "Color2": {
+        "MainToolbarGradientStart": "#EEE2BD",
+        "Avatar": {
+          "Start": "#B08B14",
+          "End": "#BB7F19"
+        }
+      },
+      "Color3": {
+        "MainToolbarGradientStart": "#DBE7C9",
+        "Avatar": {
+          "Start": "#A1A359",
+          "End": "#87AA59"
+        }
+      },
+      "Color4": {
+        "MainToolbarGradientStart": "#CADFEA",
+        "Avatar": {
+          "Start": "#3B92B8",
+          "End": "#6183EC"
+        }
+      },
+      "Color5": {
+        "MainToolbarGradientStart": "#DBD8EF",
+        "Avatar": {
+          "Start": "#3574F0",
+          "End": "#7A64F0"
+        }
+      },
+      "Color6": {
+        "MainToolbarGradientStart": "#EED7F5",
+        "Avatar": {
+          "Start": "#C84D8F",
+          "End": "#A956CF"
+        }
+      },
+      "Color7": {
+        "MainToolbarGradientStart": "#DFCCF4",
+        "Avatar": {
+          "Start": "#955AE0",
+          "End": "#A84DE0"
+        }
+      },
+      "Color8": {
+        "MainToolbarGradientStart": "#BEE4E1",
+        "Avatar": {
+          "Start": "#24A394",
+          "End": "#279CCD"
+        }
+      },
+      "Color9": {
+        "MainToolbarGradientStart": "#CCEBD1",
+        "Avatar": {
+          "Start": "#5FAD65",
+          "End": "#3D968B"
+        }
+      }
+    },
+
+    "RunWidget" : {
+      "foreground": "Grey1",
+      "runningBackground": "Green5",
+      "stopBackground": "Red5",
+      "hoverBackground": "#00000022",
+      "pressedBackground": "#00000028",
+      "iconColor": "Grey6",
+      "runIconColor": "Green5",
+      "runningIconColor": "Grey14"
     }
   }
 }


### PR DESCRIPTION
Fix icon color of RunWidget and background color of RecentProject of new UI, refer to `Light with Light Header theme`.
1. The icon color of RunWidge is too light to see;
2. The background color of RecentProject is too dark.

Just copied _RunWidget_ and _RecentProject_ in the theme file of `Light with Light Header theme`