### PR TITLE
Several fixes for VScode Light Modern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- VScode Light Modern — fix xml foreground color purple to blue(0000ff same as VSCode) by @trofoto
+- VScode Light Modern — fix the colors of tooltip in the editor, especially the background color with same color with text by @trofoto
+
 ## 1.10.9 - 2024-01-21
 
 ### Fixed:

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = com.github.dinbtechit.vscodetheme
 pluginName = VSCode Theme
 # SemVer format -> https://semver.org
-pluginVersion = 1.10.9
+pluginVersion = 1.10.10
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/src/main/resources/themes/vscode_light.theme.json
+++ b/src/main/resources/themes/vscode_light.theme.json
@@ -44,7 +44,7 @@
     "Green7": "#89C398",
     "Green8": "#AFDBB8",
     "Green9": "#C5E5CC",
-    "Green10": "#E6F7E9",
+    "Green10": "#E3F7E7",
     "Green11": "#F2FCF3",
 
     "Yellow1": "#A46704",
@@ -55,7 +55,7 @@
     "Yellow6": "#FED277",
     "Yellow7": "#FEE6B1",
     "Yellow8": "#FFF1D1",
-    "Yellow9": "#FFF6DE",
+    "Yellow9": "#FFF5DB",
     "Yellow10": "#FFFAEB",
 
     "Red1": "#AD2B38",
@@ -67,8 +67,9 @@
     "Red7": "#ED99A1",
     "Red8": "#F2B6BB",
     "Red9": "#FAD4D8",
-    "Red10": "#FFF2F3",
-    "Red11": "#FFF7F7",
+    "Red10": "#FFEBEC",
+    "Red11": "#FFF2F3",
+    "Red12": "#FFF7F7",
 
     "Orange1": "#A14916",
     "Orange2": "#B85516",
@@ -77,7 +78,7 @@
     "Orange5": "#EC8F4C",
     "Orange6": "#F2B181",
     "Orange7": "#F9D2B6",
-    "Orange8": "#FCE6D6",
+    "Orange8": "#FFEFE3",
     "Orange9": "#FFF4EB",
 
     "Teal1": "#096A6E",
@@ -98,7 +99,8 @@
     "Purple6": "#BFA1F8",
     "Purple7": "#DCCBFB",
     "Purple8": "#EFE5FF",
-    "Purple9": "#FAF5FF"
+    "Purple9": "#F5EDFF",
+    "Purple10": "#FAF5FF"
   },
 
   "ui": {
@@ -113,7 +115,24 @@
     },
 
     "Editor": {
-      "background": "#FFFFFF"
+      "SearchField" : {
+        "background": "Grey14"
+      },
+      "Toolbar" : {
+        "borderColor" : "Grey12"
+      },
+      "ToolTip": {
+        "foreground": "Grey1",
+        "background": "Grey14",
+        "border": "Grey9",
+        "errorBackground": "Red12",
+        "errorBorder": "Red9",
+        "successBackground": "Green11",
+        "successBorder": "Green8",
+        "warningBackground": "Yellow9",
+        "warningBorder": "Yellow6",
+        "selectionBackground": "Grey12"
+      }
     },
 
     "SearchMatch": {

--- a/src/main/resources/themes/vscode_light_modern.xml
+++ b/src/main/resources/themes/vscode_light_modern.xml
@@ -1683,7 +1683,7 @@
         </option>
         <option name="XML_ATTRIBUTE_VALUE">
             <value>
-                <option name="FOREGROUND" value="a31515"/>
+                <option name="FOREGROUND" value="0000ff"/>
             </value>
         </option>
         <option name="XML_ENTITY_REFERENCE">


### PR DESCRIPTION
### Fixed:
- VScode Light Modern — fix xml foreground color purple to blue(0000ff same as VSCode)
- VScode Light Modern — fix the colors of tooltip in the editor, especially the background color with same color with text

#### Jetbrains Screenshot
##### Before
![image](https://github.com/dinbtechit/vscode-theme/assets/8140291/120735bc-c468-4813-b5a4-a57b5104cfba)
And
![image](https://github.com/dinbtechit/vscode-theme/assets/8140291/c903bc4f-3024-44d8-91df-6b2fcc7cdf53)

##### After
![image](https://github.com/dinbtechit/vscode-theme/assets/8140291/b34be730-349f-4ca5-bec2-5248b38ecdf0)
And
![image](https://github.com/dinbtechit/vscode-theme/assets/8140291/1d291c32-a0ab-44be-92e7-adbd35f4346a)

