### PR TITLE
Feature for #210 - Categorize async Python keyword as a primary keyword when used in function declaration

### DIFF
--- a/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/PyAnnotator.kt
+++ b/src/main/kotlin/com/github/dinbtechit/vscodetheme/annotators/PyAnnotator.kt
@@ -104,10 +104,8 @@ class PyAnnotator : BaseAnnotator() {
             "self" -> type = DEFAULT_KEYWORD
             "await" ->
                 type =
-                    if(isJupyterNoteBook(element))
-                        SECONDARY_KEYWORD_WITH_BG_JUPYTER
-                    else
-                        SECONDARY_KEYWORD_WITH_BG
+                    if (isJupyterNoteBook(element)) SECONDARY_KEYWORD_WITH_BG_JUPYTER
+                    else SECONDARY_KEYWORD_WITH_BG
             "async" -> {
                 type =
                     generateSequence(element.nextSibling) { it.nextSibling }


### PR DESCRIPTION
This is the code to implement the feature from #210.

It adds logic to categorize the `async` Python keyword as a primary keyword when it is followed by `def` as part of a function declaration. 

Before:
<img width="402" alt="image" src="https://github.com/user-attachments/assets/195a027a-b8ad-42b5-98f2-5fe44bb9b825">

After:
<img width="404" alt="image" src="https://github.com/user-attachments/assets/5b70da87-2bae-4963-a544-32cc9ff24584">
