### PR TITLE
Feature/yaml and light adjustement

### DIFF
--- a/src/main/resources/themes/vscode_dark.xml
+++ b/src/main/resources/themes/vscode_dark.xml
@@ -1297,5 +1297,16 @@
                 <option name="EFFECT_TYPE" value="1"/>
             </value>
         </option>
+        <option name="YAML_ANCHOR">
+            <value>
+                <option name="FOREGROUND" value="94dbfd" />
+            </value>
+        </option>
+        <option name="YAML_TEXT">
+            <value>
+                <option name="FOREGROUND" value="cd9069" />
+                <option name="EFFECT_TYPE" value="5" />
+            </value>
+        </option>
     </attributes>
 </scheme>

--- a/src/main/resources/themes/vscode_light_modern.xml
+++ b/src/main/resources/themes/vscode_light_modern.xml
@@ -1659,10 +1659,9 @@
         </option>
         <option name="WARNING_ATTRIBUTES">
             <value>
-                <option name="BACKGROUND" value="f6ebbc"/>
-                <option name="EFFECT_COLOR" value="3b3b3b"/>
-                <option name="ERROR_STRIPE_COLOR" value="ffff00"/>
-                <option name="EFFECT_TYPE" value="1"/>
+                <option name="EFFECT_COLOR" value="be9117"/>
+                <option name="ERROR_STRIPE_COLOR" value="be9117"/>
+                <option name="EFFECT_TYPE" value="2"/>
             </value>
         </option>
         <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">

--- a/src/main/resources/themes/vscode_light_modern.xml
+++ b/src/main/resources/themes/vscode_light_modern.xml
@@ -1706,6 +1706,11 @@
                 <option name="FOREGROUND" value="800000"/>
             </value>
         </option>
+        <option name="YAML_ANCHOR">
+            <value>
+                <option name="FOREGROUND" value="1080" />
+            </value>
+        </option>
         <option name="YAML_COMMENT">
             <value>
                 <option name="FOREGROUND" value="8000"/>
@@ -1743,7 +1748,7 @@
         </option>
         <option name="YAML_TEXT">
             <value>
-                <option name="FOREGROUND" value="a31515"/>
+                <option name="FOREGROUND" value="ff" />
             </value>
         </option>
 


### PR DESCRIPTION
Lately, I’ve been working a lot with YAML and noticed that the colors differ from those used in VSCode. I fixed that.

| Before | After | VSCode |
|---|---|---|
|<img width="399" height="233" alt="image" src="https://github.com/user-attachments/assets/8d57fecd-3d44-44b0-9445-0d73d7863ba7" />|<img width="493" height="224" alt="image" src="https://github.com/user-attachments/assets/9a5f2e90-b14b-4951-a96c-2aa3d1567f6b" />|<img width="521" height="225" alt="image" src="https://github.com/user-attachments/assets/f517dc05-b0e4-4c96-aecd-f4471d92b9a1" />|

I also fixed the warning colors in the light theme. 

| Before | After | VSCode |
|---|---|---|
|<img width="323" height="75" alt="image" src="https://github.com/user-attachments/assets/661c9dc2-9c93-4572-8c83-891856825d6c" />|<img width="304" height="65" alt="image" src="https://github.com/user-attachments/assets/66cf71ad-2d82-4ddd-ba7c-baf1a979b071" />|<img width="343" height="60" alt="image" src="https://github.com/user-attachments/assets/814214fa-e039-4037-9c05-183b33d08bab" />|
