### PR TITLE
Fixed border contast in Dark Modern theme

### DIFF
--- a/src/main/resources/themes/vscode_dark_brighter.xml
+++ b/src/main/resources/themes/vscode_dark_brighter.xml
@@ -233,7 +233,7 @@
         <option name="DART_SECONDARY_KEYWORD_WITH_BG">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
             </value>
         </option>
         <option name="DEFAULT_BLOCK_COMMENT">
@@ -370,7 +370,7 @@
         <option name="DEFAULT_SECONDARY_KEYWORD_WITH_BG">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
             </value>
         </option>
         <option name="DEFAULT_SEMICOLON">
@@ -590,7 +590,7 @@
         <option name="JS.FROM_KEYWORD">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
             </value>
         </option>
         <option name="JS.GLOBAL_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
@@ -978,7 +978,7 @@
         <option name="PY.CLASS_REFERENCE">
             <value>
                 <option name="FOREGROUND" value="47ccb1"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
             </value>
         </option>
         <option name="PY.Jupyter.CLASS_REFERENCE">
@@ -1001,7 +1001,7 @@
         <option name="PY.FUNCTION_CALL">
             <value>
                 <option name="FOREGROUND" value="e6e6aa"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
             </value>
         </option>
         <option name="PY.Jupyter.FUNCTION_CALL">
@@ -1013,7 +1013,7 @@
         <option name="PY.IMPORTS">
             <value>
                 <option name="FOREGROUND" value="47ccb1"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
             </value>
         </option>
         <option name="PY.Jupyter.IMPORTS">
@@ -1050,7 +1050,7 @@
         <option name="PY.SECONDARY_KEYWORD_WITH_BG">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
             </value>
         </option>
         <option name="PY.Jupyter.SECONDARY_KEYWORD_WITH_BG">
@@ -1079,7 +1079,7 @@
         </option>
         <option name="ReSharper.ASP_NET_RAZOR_CODE_BLOCK">
             <value>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>
@@ -1167,7 +1167,7 @@
         <option name="TEXT">
             <value>
                 <option name="FOREGROUND" value="d4d4d4"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>
@@ -1186,7 +1186,7 @@
         <option name="TS.FROM_KEYWORD">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
             </value>
         </option>
         <option name="TS.MODULE_KEYWORD">
@@ -1229,14 +1229,14 @@
         <option name="XML_PROLOGUE">
             <value>
                 <option name="FOREGROUND" value="d4d4d4"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>
         <option name="XML_TAG">
             <value>
                 <option name="FOREGROUND" value="d4d4d4"/>
-                <option name="BACKGROUND" value="1e1e1e"/>
+                <option name="BACKGROUND" value="242424"/>
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>

--- a/src/main/resources/themes/vscode_dark_modern.theme.json
+++ b/src/main/resources/themes/vscode_dark_modern.theme.json
@@ -5,7 +5,7 @@
   "editorScheme": "/themes/vscode_dark_brighter.xml",
   "ui": {
     "*": {
-      "background": "#181818",
+      "background": "#1e1e1e",
       "foreground": "#DFDFE0",
 
       "infoForeground": "#A9A9AA",
@@ -18,8 +18,8 @@
       "lightSelectionInactiveBackground": "#37373d",
       "lightSelectionInactiveForeground": "#DFDFE0",
 
-      "disabledBackground": "#181818",
-      "inactiveBackground": "#181818",
+      "disabledBackground": "#1e1e1e",
+      "inactiveBackground": "#1e1e1e",
 
       "disabledForeground": "#737374",
       "disabledText": "#737374",
@@ -177,11 +177,11 @@
       }
     },
     "ToolWindow": {
-      "background": "#181818",
+      "background": "#1e1e1e",
       "Header.borderColor": "#ffffff12"
     },
     "Tree": {
-      "background": "#181818"
+      "background": "#1e1e1e"
     },
 
 
@@ -190,7 +190,7 @@
     },
 
     "WelcomeScreen": {
-      "background": "#181818",
+      "background": "#1e1e1e",
       "SidePanel.background": "#1e1e1e",
       "borderColor": "#ffffff12",
       "Projects.background": "#1e1e1e",

--- a/src/main/resources/themes/vscode_dark_modern.theme.json
+++ b/src/main/resources/themes/vscode_dark_modern.theme.json
@@ -28,8 +28,8 @@
       "acceleratorForeground": "#D0D0D9",
       "acceleratorSelectionForeground": "#D0D0D9",
 
-      "borderColor": "#414141",
-      "disabledBorderColor": "#414141",
+      "borderColor": "#2f2f2f",
+      "disabledBorderColor": "#2f2f2f",
 
       "focusColor": "#24648D",
       "focusedBorderColor": "#4C8CB5",
@@ -101,7 +101,7 @@
       "foreground": "#000000"
     },
 
-    "DebuggerPopup.borderColor": "#414141",
+    "DebuggerPopup.borderColor": "#2f2f2f",
 
     "DefaultTabs": {
       "borderColor": "#484949",
@@ -116,7 +116,7 @@
     "DragAndDrop": {
       "areaForeground": "#DFDFE0",
       "areaBackground": "#363737",
-      "borderColor": "#414141"
+      "borderColor": "#2f2f2f"
     },
 
     "Editor": {


### PR DESCRIPTION
Hello, this plugin has been super helpful with adjusting to Android Studio. Something I noticed that kinda bothered me though was that the border colors in the dark modern theme are a bit off, creating a higher contrast between panes. This pull requests changes the border color to match VSCode more accurately. Only tested on Android Studio.

Resolves negative [Jetbrains review](https://plugins.jetbrains.com/plugin/19177-vscode-theme/reviews#124568)

VSCode Dark Modern: 
<img width="2559" height="1381" alt="Screenshot_20260218_235003" src="https://github.com/user-attachments/assets/108cb867-5d60-48ca-83b7-eaa69f8e31e2" />
<img width="714" height="475" alt="Screenshot_20260218_235003_crop" src="https://github.com/user-attachments/assets/ad8ebf82-1f24-4410-9566-781d0ec22f48" />

This plugin (before): 
<img width="2559" height="1389" alt="Screenshot_20260218_234940" src="https://github.com/user-attachments/assets/7b508b85-ad4d-460e-9f87-024b0fa7d453" />
<img width="822" height="516" alt="Screenshot_20260218_234940_crop" src="https://github.com/user-attachments/assets/0d5fe273-4325-4c0a-a228-26bef4a3a8c8" />


After: 
<img width="2559" height="1381" alt="Screenshot_20260219_020412" src="https://github.com/user-attachments/assets/7d22eb5a-afbc-4429-9c52-d2729b7ce4bd" />
<img width="804" height="528" alt="Screenshot_20260219_020412_crop" src="https://github.com/user-attachments/assets/af1e3b0f-505f-48f4-8819-cb619afbbad1" />
