### PR TITLE
feat(theme): add VSCode 2026 Dark and Light themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ This plugin aims to closely emulate the VSCode theme within the IDE, simplifying
 **Dark:**
 - VSCode Dark+
 - VSCode Dark Modern
+- VSCode 2026 Dark
 
 **Light:**
 - VSCode Light Modern (Experimental - Feel free to report bugs at https://github.com/dinbtechit/vscode-theme/issues)
+- VSCode 2026 Light
 
 **For Best Viewing Experience:** 
 - Plugins: VSCode Theme + Rainbow Brackets

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,9 +29,13 @@
         <themeProvider order="first" id="dinbtechit-2179230b863b9b1d9f1eeb27ca4a3a70" path="themes/vscode_dark_modern.theme.json"/>
         <themeProvider order="last" id="dinbtechit-7ef0c378d737e162955f3e028dcf9ccb" path="themes/vscode_dark.theme.json"/>
         <themeProvider order="last" id="dinbtechit-e4968811e8c127f591d7e670706d4a3c" path="themes/vscode_light.theme.json"/>
+        <themeProvider order="last" id="dinbtechit-vscode-2026-dark" path="themes/vscode_2026_dark.theme.json"/>
+        <themeProvider order="last" id="dinbtechit-vscode-2026-light" path="themes/vscode_2026_light.theme.json"/>
         <bundledColorScheme id="dinbtechit-7ef0c378d737e162955f3e028dcf9ccb3" path="themes/vscode_dark"/>
         <bundledColorScheme id="dinbtechit-7ef0c378d737e162955f3e028dcf9ccb4" path="themes/vscode_dark_brighter"/>
         <bundledColorScheme id="dinbtechit-e4968811e8c127f591d7e670706d4a3f" path="themes/vscode_light_modern"/>
+        <bundledColorScheme id="dinbtechit-vscode-2026-dark-scheme" path="themes/vscode_2026_dark"/>
+        <bundledColorScheme id="dinbtechit-vscode-2026-light-scheme" path="themes/vscode_2026_light"/>
         <postStartupActivity implementation="com.github.dinbtechit.vscodetheme.startup.VSCodeStartupNotifyActivity"/>
         <applicationService
                 serviceImplementation="com.github.dinbtechit.vscodetheme.settings.VSCodeThemeSettingsStore"/>

--- a/src/main/resources/themes/vscode_2026_dark.theme.json
+++ b/src/main/resources/themes/vscode_2026_dark.theme.json
@@ -1,0 +1,167 @@
+{
+  "name": "VS Code 2026 Dark",
+  "dark": true,
+  "author": "Dinesh Srinivasan",
+  "editorScheme": "/themes/vscode_2026_dark.xml",
+  "ui": {
+    "*": {
+      "background": "#191A1B",
+      "foreground": "#BFBFBF",
+      "infoForeground": "#8C8C8C",
+      "selectionInactiveBackground": "#2C2D2E",
+      "selectionBackgroundInactive": "#2C2D2E",
+      "lightSelectionBackground": "#3994BC26",
+      "lightSelectionForeground": "#EDEDED",
+      "lightSelectionInactiveBackground": "#2C2D2E",
+      "lightSelectionInactiveForeground": "#EDEDED",
+      "disabledBackground": "#191A1B",
+      "inactiveBackground": "#191A1B",
+      "disabledForeground": "#555555",
+      "disabledText": "#555555",
+      "inactiveForeground": "#8C8C8C",
+      "acceleratorForeground": "#BFBFBF",
+      "acceleratorSelectionForeground": "#BFBFBF",
+      "borderColor": "#2A2B2C",
+      "disabledBorderColor": "#2A2B2C",
+      "focusColor": "#3994BCB3",
+      "focusedBorderColor": "#333536",
+      "separatorForeground": "#2A2B2C",
+      "separatorColor": "#2A2B2C",
+      "lineSeparatorColor": "#2A2B2C",
+      "modifiedItemForeground": "#E5BA7D"
+    },
+    "ActionButton": {
+      "hoverBackground": "#2B7DA3",
+      "hoverBorderColor": "#2B7DA3",
+      "pressedBackground": "#3994BC",
+      "pressedBorderColor": "#3994BC"
+    },
+    "Button": {
+      "startBackground": "#242526",
+      "endBackground": "#242526",
+      "startBorderColor": "#333536",
+      "endBorderColor": "#333536",
+      "shadowColor": "#191A1B",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "#297AA0",
+        "endBackground": "#297AA0",
+        "startBorderColor": "#333536",
+        "endBorderColor": "#333536",
+        "focusedBorderColor": "#3994BC",
+        "focusColor": "#3994BCB3",
+        "shadowColor": "#191A1B"
+      }
+    },
+    "Borders": {
+      "color": "#2A2B2C",
+      "ContrastBorderColor": "#333536"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "#191A1B",
+      "background": "#191A1B",
+      "modifiedItemForeground": "#48A0C7",
+      "ArrowButton": {
+        "iconColor": "#BFBFBF",
+        "background": "#191A1B",
+        "disabledIconColor": "#555555",
+        "nonEditableBackground": "#191A1B"
+      }
+    },
+    "ComboPopup.border": "1,1,1,1,#2A2B2C",
+    "Component": {
+      "errorFocusColor": "#3A1D1D",
+      "inactiveErrorFocusColor": "#3A1D1D",
+      "warningFocusColor": "#352A05",
+      "inactiveWarningFocusColor": "#352A05",
+      "iconColor": "#8C8C8C",
+      "hoverIconColor": "#BFBFBF"
+    },
+    "Counter": {
+      "background": "#3994BC",
+      "foreground": "#FFFFFF"
+    },
+    "DebuggerPopup.borderColor": "#2A2B2C",
+    "DefaultTabs": {
+      "borderColor": "#2A2B2C",
+      "background": "#191A1B",
+      "inactiveUnderlineColor": "#2A2B2C",
+      "hoverBackground": "#121314",
+      "underlineColor": "#3994BC",
+      "underlineHeight": 2,
+      "underlinedTabBackground": "#121314"
+    },
+    "DragAndDrop": {
+      "areaForeground": "#BFBFBF",
+      "areaBackground": "#242526",
+      "borderColor": "#2A2B2C"
+    },
+    "Editor": {
+      "background": "#121314",
+      "SearchField.background": "#202122"
+    },
+    "EditorTabs": {
+      "tabInsets": true,
+      "underlinedTabBackground": "#121314",
+      "inactiveColoredFileBackground": "#242526"
+    },
+    "FileColor": {
+      "Yellow": "#352A05",
+      "Green": "#1E3A47",
+      "Blue": "#202122",
+      "Violet": "#242526",
+      "Orange": "#352A05",
+      "Rose": "#3A1D1D"
+    },
+    "Toolbar.Floating.borderColor": "#2A2B2C",
+    "ToolWindow.Header": {
+      "borderColor": "#2A2B2C"
+    },
+    "Notification": {
+      "background": "#202122",
+      "borderColor": "#2A2B2C"
+    },
+    "NotificationsToolwindow": {
+      "newNotification.background": "#242526"
+    },
+    "SearchMatch": {
+      "startBackground": "#27678290",
+      "endBackground": "#27678280"
+    },
+    "ToggleButton": {
+      "onBackground": "#3994BC"
+    },
+    "CompletionPopup": {
+      "matchForeground": "#48A0C7"
+    },
+    "Popup": {
+      "Header": {
+        "activeBackground": "#202122",
+        "inactiveBackground": "#191A1B"
+      }
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedForeground": "#EDEDED",
+        "selectedBackground": "#3994BC26"
+      }
+    },
+    "ToolWindow": {
+      "background": "#191A1B",
+      "Header.borderColor": "#2A2B2C"
+    },
+    "Tree": {
+      "background": "#191A1B"
+    },
+    "Plugins": {
+      "borderColor": "#2A2B2C"
+    },
+    "WelcomeScreen": {
+      "background": "#191A1B",
+      "SidePanel.background": "#191A1B",
+      "borderColor": "#2A2B2C",
+      "Projects.background": "#121314",
+      "Projects.actions.background": "#191A1B"
+    }
+  }
+}

--- a/src/main/resources/themes/vscode_2026_dark.xml
+++ b/src/main/resources/themes/vscode_2026_dark.xml
@@ -1,0 +1,1381 @@
+<scheme name="VSCode 2026 Dark" version="142" parent_scheme="Darcula">
+    <metaInfo>
+        <property name="created">2023-08-13T10:41:00</property>
+        <property name="ide">idea</property>
+        <property name="ideVersion">2023.1.1.0.0</property>
+        <property name="modified">2023-08-13T10:41:08</property>
+        <property name="originalScheme">_@user_VSCode 2026 Dark</property>
+    </metaInfo>
+    <colors>
+        <option name="CARET_COLOR" value="bbbebf"/>
+        <option name="CARET_ROW_COLOR" value="242526"/>
+        <option name="CONSOLE_BACKGROUND_KEY" value="191a1b"/>
+        <option name="GUTTER_BACKGROUND" value="121314"/>
+        <option name="INDENT_GUIDE" value="838485"/>
+        <option name="LINE_NUMBERS_COLOR" value="858889"/>
+        <option name="RIGHT_MARGIN_COLOR" value="848484"/>
+        <option name="SELECTION_BACKGROUND" value="276782"/>
+        <option name="VISUAL_INDENT_GUIDE" value="838485"/>
+        <option name="JUPYTER.CODE_CELL_BACKGROUND" value="202122"/>
+    </colors>
+    <attributes>
+        <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="ANNOTATION_NAME_ATTRIBUTES" baseAttributes="DEFAULT_METADATA"/>
+        <option name="BAD_CHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="f48771"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="BASH.BACKQUOTE">
+            <value>
+                <option name="FOREGROUND" value="cd905b"/>
+            </value>
+        </option>
+        <option name="BASH.EXTERNAL_COMMAND">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="BASH.HERE_DOC_END">
+            <value>
+                <option name="FOREGROUND" value="c586c0"/>
+            </value>
+        </option>
+        <option name="BASH.HERE_DOC_START">
+            <value>
+                <option name="FOREGROUND" value="c586c0"/>
+            </value>
+        </option>
+        <option name="BASH.SHEBANG" baseAttributes="BASH.LINE_COMMENT"/>
+        <option name="BASH.VAR_USE">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="CMD_EXPRESSION">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="CMD_LABEL">
+            <value>
+                <option name="FOREGROUND" value="d3d3c8"/>
+            </value>
+        </option>
+        <option name="CMD_LABEL_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="d3d3c8"/>
+            </value>
+        </option>
+        <option name="CONSOLE_BLACK_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="6871ff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_BLUE_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="5cbb"/>
+            </value>
+        </option>
+        <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="60fdff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_CYAN_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="60fdff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_DARKGRAY_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="686868"/>
+            </value>
+        </option>
+        <option name="CONSOLE_GRAY_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="c9c9c9"/>
+            </value>
+        </option>
+        <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="5ffa68"/>
+            </value>
+        </option>
+        <option name="CONSOLE_GREEN_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="48d53b"/>
+            </value>
+        </option>
+        <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff77ff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_MAGENTA_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="c930c7"/>
+            </value>
+        </option>
+        <option name="CONSOLE_NORMAL_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_RED_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff4050"/>
+            </value>
+        </option>
+        <option name="CONSOLE_RED_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="c91b00"/>
+            </value>
+        </option>
+        <option name="CONSOLE_SYSTEM_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_WHITE_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="fffc67"/>
+            </value>
+        </option>
+        <option name="CONSOLE_YELLOW_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="c7c400"/>
+            </value>
+        </option>
+        <option name="CSS.ATTRIBUTE_NAME">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="CSS.CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="d7ba7d"/>
+            </value>
+        </option>
+        <option name="CSS.FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="CSS.IDENT">
+            <value>
+                <option name="FOREGROUND" value="d4d4d4"/>
+            </value>
+        </option>
+        <option name="CSS.IMPORTANT">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="CSS.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="c586c0"/>
+            </value>
+        </option>
+        <option name="CSS.PSEUDO">
+            <value>
+                <option name="FOREGROUND" value="d7ba7d"/>
+            </value>
+        </option>
+        <option name="CSS.TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="d7ba7d"/>
+            </value>
+        </option>
+        <option name="CSS.URL">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="CTRL_CLICKABLE">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+                <option name="EFFECT_COLOR" value="589df6"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="DART_CONSTRUCTOR">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="DART_ENUM_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+            </value>
+        </option>
+        <option name="DART_SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+            </value>
+        </option>
+        <option name="DART_SECONDARY_KEYWORD_WITH_BG">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+                <option name="BACKGROUND" value="121314"/>
+            </value>
+        </option>
+        <option name="DEFAULT_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="699856"/>
+            </value>
+        </option>
+        <option name="DEFAULT_CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="7ee787"/>
+            </value>
+        </option>
+        <option name="DEFAULT_CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="7ee787"/>
+            </value>
+        </option>
+        <option name="DEFAULT_COMMA">
+            <value/>
+        </option>
+        <option name="DEFAULT_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="79c0ff"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8b949e"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT_TAG">
+            <value>
+                <option name="FOREGROUND" value="79c0ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+            <value>
+                <option name="FOREGROUND" value="a5d6ff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_MARKUP">
+            <value>
+                <option name="FOREGROUND" value="79c0ff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="d2a8ff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_FUNCTION_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="d2a8ff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="ffa657"/>
+            </value>
+        </option>
+        <option name="DEFAULT_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="c9d1d9"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INSTANCE_FIELD">
+            <value>
+                <option name="FOREGROUND" value="79c0ff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INTERFACE_NAME">
+            <value>
+                <option name="FOREGROUND" value="7ee787"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="f48771"/>
+                <option name="EFFECT_COLOR" value="f48771"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff7b72"/>
+            </value>
+        </option>
+        <option name="DEFAULT_LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8b949e"/>
+            </value>
+        </option>
+        <option name="DEFAULT_LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+            </value>
+        </option>
+        <option name="DEFAULT_METADATA">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="DEFAULT_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="b4cda8"/>
+            </value>
+        </option>
+        <option name="DEFAULT_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+            </value>
+        </option>
+        <option name="DEFAULT_REASSIGNED_LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="EFFECT_COLOR" value="707d95"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="DEFAULT_REASSIGNED_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="EFFECT_COLOR" value="707d95"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="DEFAULT_SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+            </value>
+        </option>
+        <option name="DEFAULT_SECONDARY_KEYWORD_WITH_BG">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+                <option name="BACKGROUND" value="121314"/>
+            </value>
+        </option>
+        <option name="DEFAULT_SEMICOLON">
+            <value/>
+        </option>
+        <option name="DEFAULT_STATIC_FIELD">
+            <value>
+                <option name="FOREGROUND" value="ffc66d"/>
+            </value>
+        </option>
+        <option name="DEFAULT_STATIC_METHOD">
+            <value>
+                <option name="FOREGROUND" value="ffc66d"/>
+            </value>
+        </option>
+        <option name="DEFAULT_STRING">
+            <value>
+                <option name="FOREGROUND" value="a5d6ff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR" baseAttributes="TEXT"/>
+        <option name="DEFAULT_VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="7ee787"/>
+            </value>
+        </option>
+        <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="48a0c7"/>
+                <option name="EFFECT_COLOR" value="a5d6ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="GO_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="6a9955"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_TYPE_REFERENCE" baseAttributes="DEFAULT_CLASS_REFERENCE"/>
+        <option name="GO_BUILTIN_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="GO_COMMENT_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="6a9955"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="GO_EXPORTED_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="GO_EXPORTED_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="GO_LABEL">
+            <value>
+                <option name="FOREGROUND" value="c8c8c8"/>
+                <option name="EFFECT_COLOR" value="323333"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="GO_LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="6a9955"/>
+            </value>
+        </option>
+        <option name="GO_LOCAL_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="c8c8c8"/>
+            </value>
+        </option>
+        <option name="GO_LOCAL_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="GO_LOCAL_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="GO_METHOD_RECEIVER" baseAttributes="DEFAULT_LOCAL_VARIABLE"/>
+        <option name="GO_PACKAGE" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="GO_PACKAGE_EXPORTED_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="GO_PACKAGE_LOCAL_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="GO_SHADOWING_VARIABLE" baseAttributes="DEFAULT_LOCAL_VARIABLE"/>
+        <option name="GO_TAG_TEXT">
+            <value>
+                <option name="FOREGROUND" value="d4d4d4"/>
+            </value>
+        </option>
+        <option name="GO_TAG_VALUE">
+            <value>
+                <option name="FOREGROUND" value="cd9069"/>
+            </value>
+        </option>
+        <option name="GO_TYPE_REFERENCE" baseAttributes="DEFAULT_CLASS_REFERENCE"/>
+        <option name="GO_VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="d7ba7d"/>
+            </value>
+        </option>
+        <option name="HTML_ATTRIBUTE_NAME">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="HTML_ATTRIBUTE_VALUE">
+            <value>
+                <option name="FOREGROUND" value="de967a"/>
+            </value>
+        </option>
+        <option name="HTML_CUSTOM_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="HTML_TAG">
+            <value>
+                <option name="FOREGROUND" value="808080"/>
+            </value>
+        </option>
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="7ee787"/>
+            </value>
+        </option>
+        <option name="HYPERLINK_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="48a0c7"/>
+                <option name="EFFECT_COLOR" value="287bde"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="JSON.IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="c9d1d9"/>
+            </value>
+        </option>
+        <option name="JSON.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff7b72"/>
+            </value>
+        </option>
+        <option name="JSON.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="79c0ff"/>
+            </value>
+        </option>
+        <option name="JSON.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="ffa657"/>
+            </value>
+        </option>
+        <option name="JSON.PROPERTY_KEY">
+            <value>
+                <option name="FOREGROUND" value="7ee787"/>
+            </value>
+        </option>
+        <option name="JSON.STRING">
+            <value>
+                <option name="FOREGROUND" value="a5d6ff"/>
+            </value>
+        </option>
+        <option name="JSON.VALID_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="7ee787"/>
+            </value>
+        </option>
+        <option name="JSON.INVALID_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="f48771"/>
+                <option name="EFFECT_COLOR" value="f48771"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="33393f"/>
+                <option name="ERROR_STRIPE_COLOR" value="a0a0a0"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="EFFECT_COLOR" value="b389c5"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="INJECTED_LANGUAGE_FRAGMENT">
+            <value/>
+        </option>
+        <option name="INSTANCE_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="INSTANCE_FINAL_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JAVA.SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+            </value>
+        </option>
+        <option name="JAVA.TYPE_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="JS.CLASS">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="JS.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="JS.DOC_TYPE">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="JS.FROM_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+                <option name="BACKGROUND" value="121314"/>
+            </value>
+        </option>
+        <option name="JS.GLOBAL_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
+        <option name="JS.GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="JS.IMPORT_SPECIFIER">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="JS.INSTANCE_MEMBER_FUNCTION" baseAttributes="DEFAULT_INSTANCE_METHOD"/>
+        <option name="JS.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="JS.LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+            </value>
+        </option>
+        <option name="JS.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="JS.SECONDARY_KEYWORDS">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+            </value>
+        </option>
+        <option name="JS.STATIC_MEMBER_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="ffc66d"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JS.STATIC_MEMBER_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="ffc66d"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="KOTLIN_ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+            </value>
+        </option>
+        <option name="KOTLIN_BACKING_FIELD_VARIABLE">
+            <value/>
+        </option>
+        <option name="KOTLIN_CLOSURE_DEFAULT_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="a9b7c6"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="KOTLIN_CONSTRUCTOR">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="KOTLIN_DYNAMIC_FUNCTION_CALL">
+            <value/>
+        </option>
+        <option name="KOTLIN_DYNAMIC_PROPERTY_CALL">
+            <value/>
+        </option>
+        <option name="KOTLIN_ENUM">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="KOTLIN_ENUM_ENTRY">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="FONT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="KOTLIN_LABEL">
+            <value>
+                <option name="FOREGROUND" value="a9b7c6"/>
+            </value>
+        </option>
+        <option name="KOTLIN_LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="a9b7c6"/>
+            </value>
+        </option>
+        <option name="KOTLIN_MUTABLE_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="a9b7c6"/>
+                <option name="EFFECT_COLOR" value="bca5c4"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="KOTLIN_NAMED_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+            </value>
+        </option>
+        <option name="KOTLIN_OBJECT">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="KOTLIN_PACKAGE_FUNCTION_CALL" baseAttributes="DEFAULT_STATIC_METHOD"/>
+        <option name="KOTLIN_TYPE_PARAMETER" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES"/>
+        <option name="MARKDOWN_AUTO_LINK">
+            <value>
+                <option name="EFFECT_COLOR" value="d4d4d4"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_BLOCK_QUOTE">
+            <value>
+                <option name="FOREGROUND" value="699856"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_BLOCK_QUOTE_MARKER">
+            <value>
+                <option name="FOREGROUND" value="699856"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_BOLD">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_CODE_BLOCK">
+            <value>
+                <option name="FOREGROUND" value="cd905b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_CODE_FENCE">
+            <value>
+                <option name="FOREGROUND" value="cd905b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_CODE_SPAN">
+            <value>
+                <option name="FOREGROUND" value="cd905b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_1">
+            <value>
+                <option name="FOREGROUND" value="4a9dd4"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_2">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_3">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_4">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_5">
+            <value>
+                <option name="FOREGROUND" value="4a9dd4"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_6">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HRULE">
+            <value/>
+        </option>
+        <option name="MARKDOWN_INLINE_HTML">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_ITALIC">
+            <value>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_ITALIC_MARKER">
+            <value/>
+        </option>
+        <option name="MARKDOWN_LINK_DESTINATION">
+            <value>
+                <option name="EFFECT_COLOR" value="d4d4d4"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LINK_TEXT">
+            <value>
+                <option name="FOREGROUND" value="a5d6ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LINK_TITLE">
+            <value>
+                <option name="FOREGROUND" value="cd905b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LIST_ITEM">
+            <value>
+                <option name="FOREGROUND" value="f3f1f1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_ORDERED_LIST">
+            <value>
+                <option name="FOREGROUND" value="f3f1f1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_TEXT">
+            <value>
+                <option name="FOREGROUND" value="f3f1f1"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_UNORDERED_LIST">
+            <value>
+                <option name="FOREGROUND" value="f3f1f1"/>
+            </value>
+        </option>
+        <option name="MATCHED_BRACE_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="323232"/>
+                <option name="FONT_TYPE" value="1"/>
+                <option name="EFFECT_COLOR" value="878787"/>
+            </value>
+        </option>
+        <option name="OC.CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="4cc9b0"/>
+            </value>
+        </option>
+        <option name="OC.CONCEPT">
+            <value>
+                <option name="FOREGROUND" value="d4d4d4"/>
+            </value>
+        </option>
+        <option name="OC.CONDITIONALLY_NOT_COMPILED">
+            <value>
+                <option name="FOREGROUND" value="808066"/>
+            </value>
+        </option>
+        <option name="OC.DIRECTIVE">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+            </value>
+        </option>
+        <option name="OC.ENUM_CONST">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="FONT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="OC.FUNCTION_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="OC.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="OC.MACRONAME">
+            <value>
+                <option name="FOREGROUND" value="358cd6"/>
+            </value>
+        </option>
+        <option name="OC.MACRO_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="4cc9b0"/>
+            </value>
+        </option>
+        <option name="OC.MESSAGE_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="OC.METHOD_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="OC.NAMESPACE_LIKE">
+            <value>
+                <option name="FOREGROUND" value="4cc9b0"/>
+            </value>
+        </option>
+        <option name="OC.OVERLOADED_OPERATOR">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="OC.PROPERTY_ATTRIBUTE">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="OC.PROTOCOL_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="4cc9b0"/>
+            </value>
+        </option>
+        <option name="OC.STRUCT_FIELD">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="OC.STRUCT_LIKE">
+            <value>
+                <option name="FOREGROUND" value="4cc9b0"/>
+            </value>
+        </option>
+        <option name="OC.TYPEDEF">
+            <value>
+                <option name="FOREGROUND" value="4cc9b0"/>
+            </value>
+        </option>
+        <option name="PHP_ALIAS_REFERENCE">
+            <value/>
+        </option>
+        <option name="PHP_CLASS">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="PHP_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="FONT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="PHP_EXEC_COMMAND_ID">
+            <value>
+                <option name="FOREGROUND" value="cd905b"/>
+            </value>
+        </option>
+        <option name="PHP_HEREDOC_ID">
+            <value>
+                <option name="FOREGROUND" value="d3d3c8"/>
+            </value>
+        </option>
+        <option name="PHP_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="PHP_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+            </value>
+        </option>
+        <option name="PHP_THIS_VAR">
+            <value>
+                <option name="FOREGROUND" value="47a2ed"/>
+            </value>
+        </option>
+        <option name="PHP_VAR">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+            </value>
+        </option>
+        <option name="PROPERTIES.INVALID_STRING_ESCAPE" baseAttributes="DEFAULT_INVALID_STRING_ESCAPE"/>
+        <option name="PROPERTIES.KEY" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="PROPERTIES.KEY_VALUE_SEPARATOR" baseAttributes="DEFAULT_OPERATION_SIGN"/>
+        <option name="PROPERTIES.VALID_STRING_ESCAPE" baseAttributes="DEFAULT_VALID_STRING_ESCAPE"/>
+        <option name="PY.BUILTIN_NAME">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="PY.CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+                <option name="BACKGROUND" value="121314"/>
+            </value>
+        </option>
+        <option name="PY.Jupyter.CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+                <option name="BACKGROUND" value="2B2D30"/>
+            </value>
+        </option>
+        <option name="PY.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="PY.DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="cd9069"/>
+            </value>
+        </option>
+        <option name="PY.FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+                <option name="BACKGROUND" value="121314"/>
+            </value>
+        </option>
+        <option name="PY.Jupyter.FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+                <option name="BACKGROUND" value="2B2D30"/>
+            </value>
+        </option>
+        <option name="PY.IMPORTS">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+                <option name="BACKGROUND" value="121314"/>
+            </value>
+        </option>
+        <option name="PY.Jupyter.IMPORTS">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+                <option name="BACKGROUND" value="2B2D30"/>
+            </value>
+        </option>
+        <option name="PY.KEYWORD_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+            </value>
+        </option>
+        <option name="PY.OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="fdfcfc"/>
+            </value>
+        </option>
+        <option name="PY.PREDEFINED_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="PY.PREDEFINED_USAGE">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="PY.SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+            </value>
+        </option>
+        <option name="PY.SECONDARY_KEYWORD_WITH_BG">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+                <option name="BACKGROUND" value="121314"/>
+            </value>
+        </option>
+        <option name="PY.Jupyter.SECONDARY_KEYWORD_WITH_BG">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+                <option name="BACKGROUND" value="2B2D30"/>
+            </value>
+        </option>
+        <option name="PY.SELF_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="569cd5"/>
+            </value>
+        </option>
+        <option name="REASSIGNED_LOCAL_VARIABLE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="94dbfd"/>
+                <option name="EFFECT_COLOR" value="707d95"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="REGEXP.CHAR_CLASS">
+            <value>
+                <option name="FOREGROUND" value="d16969"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_RAZOR_CODE_BLOCK">
+            <value>
+                <option name="BACKGROUND" value="121314"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="ReSharper.CSHARP_CONSTANT_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="FONT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="ReSharper.CSHARP_NAMESPACE_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="SASS_COMMENT" baseAttributes="CSS.COMMENT"/>
+        <option name="SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="SQL_COLUMN">
+            <value>
+                <option name="FOREGROUND" value="d3d3c8"/>
+            </value>
+        </option>
+        <option name="SQL_DATABASE_OBJECT">
+            <value>
+                <option name="FOREGROUND" value="d3d3c8"/>
+            </value>
+        </option>
+        <option name="SQL_PROCEDURE">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="SQL_SCHEMA">
+            <value>
+                <option name="FOREGROUND" value="d3d3c8"/>
+            </value>
+        </option>
+        <option name="SQL_TABLE">
+            <value>
+                <option name="FOREGROUND" value="d3d3c8"/>
+            </value>
+        </option>
+        <option name="STATIC_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffc66d"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="FONT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="STATIC_METHOD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffc66d"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="SWIFT_PROPERTY">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="SWIFT_TUPLE_LABEL">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="SWIFT_WILDCARD">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="Static method access" baseAttributes="STATIC_METHOD_ATTRIBUTES"/>
+        <option name="TERMINAL_COMMAND_TO_RUN_USING_IDE">
+            <value>
+                <option name="BACKGROUND" value="323333"/>
+            </value>
+        </option>
+        <option name="TEXT">
+            <value>
+                <option name="FOREGROUND" value="d4d4d4"/>
+                <option name="BACKGROUND" value="121314"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="TODO_DEFAULT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="a8c023"/>
+                <option name="ERROR_STRIPE_COLOR" value="977ab"/>
+            </value>
+        </option>
+        <option name="TS.ENUM_MEMBER">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="FONT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="TS.FROM_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+                <option name="BACKGROUND" value="121314"/>
+            </value>
+        </option>
+        <option name="TS.MODULE_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cc85c6"/>
+            </value>
+        </option>
+        <option name="TS.PRIMITIVE.TYPES">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="WARNING_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="be9117"/>
+                <option name="ERROR_STRIPE_COLOR" value="be9117"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="XML_ATTRIBUTE_NAME">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="XML_CUSTOM_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="XML_ENTITY_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="XML_PROLOGUE">
+            <value>
+                <option name="FOREGROUND" value="d4d4d4"/>
+                <option name="BACKGROUND" value="121314"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="XML_TAG">
+            <value>
+                <option name="FOREGROUND" value="d4d4d4"/>
+                <option name="BACKGROUND" value="121314"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="XML_TAG_DATA" baseAttributes="TEXT"/>
+        <option name="XML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="7ee787"/>
+            </value>
+        </option>
+        <option name="XPATH.KEYWORD" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="XPATH.XPATH_VARIABLE" baseAttributes="DEFAULT_LOCAL_VARIABLE"/>
+
+        <option name="HCL.BLOCK_FIRST_TYPE_KEY">
+            <value>
+                <option name="FOREGROUND" value="4cc9b0"/>
+            </value>
+        </option>
+        <option name="HCL.BLOCK_NAME_KEY">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="HCL.BLOCK_SECOND_TYPE_KEY">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+                <option name="EFFECT_COLOR" value="4fc1ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="HCL.FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="HCL.SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="c586c0"/>
+            </value>
+        </option>
+        <option name="HCL.TYPE">
+            <value>
+                <option name="FOREGROUND" value="c586c0"/>
+            </value>
+        </option>
+
+        <option name="TIL.BRACES">
+            <value>
+                <option name="FOREGROUND" value="569cd6"/>
+            </value>
+        </option>
+        <option name="TIL.PROPERTY_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+            </value>
+        </option>
+        <option name="TIL.RESOURCE_INSTANCE_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="TIL.RESOURCE_TYPE_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="8cd7ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ReSharper.FORMAT_STRING_ITEM">
+            <value>
+                <option name="FOREGROUND" value="646695"/>
+            </value>
+        </option>
+        <option name="ReSharper.FSHARP_COMPUTATION_EXPRESSION_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="ReSharper.FSHARP_FUNCTION_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="e6e6aa"/>
+            </value>
+        </option>
+        <option name="ReSharper.FSHARP_NAMESPACE_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="47ccb1"/>
+            </value>
+        </option>
+        <option name="ReSharper.FSHARP_OPERATOR_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="569cd6"/>
+            </value>
+        </option>
+        <option name="ReSharper.FSHARP_UNION_CASE_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="4fc1ff"/>
+            </value>
+        </option>
+    </attributes>
+</scheme>

--- a/src/main/resources/themes/vscode_2026_dark.xml
+++ b/src/main/resources/themes/vscode_2026_dark.xml
@@ -10,7 +10,7 @@
         <option name="CARET_COLOR" value="bbbebf"/>
         <option name="CARET_ROW_COLOR" value="242526"/>
         <option name="CONSOLE_BACKGROUND_KEY" value="191a1b"/>
-        <option name="GUTTER_BACKGROUND" value="121314"/>
+        <option name="GUTTER_BACKGROUND" value="191a1c"/>
         <option name="INDENT_GUIDE" value="838485"/>
         <option name="LINE_NUMBERS_COLOR" value="858889"/>
         <option name="RIGHT_MARGIN_COLOR" value="848484"/>
@@ -233,7 +233,7 @@
         <option name="DART_SECONDARY_KEYWORD_WITH_BG">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
             </value>
         </option>
         <option name="DEFAULT_BLOCK_COMMENT">
@@ -370,7 +370,7 @@
         <option name="DEFAULT_SECONDARY_KEYWORD_WITH_BG">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
             </value>
         </option>
         <option name="DEFAULT_SEMICOLON">
@@ -383,7 +383,7 @@
         </option>
         <option name="DEFAULT_STATIC_METHOD">
             <value>
-                <option name="FOREGROUND" value="ffc66d"/>
+                <option name="FOREGROUND" value="d2a8ff"/>
             </value>
         </option>
         <option name="DEFAULT_STRING">
@@ -606,12 +606,17 @@
         </option>
         <option name="JAVA.SECONDARY_KEYWORD">
             <value>
-                <option name="FOREGROUND" value="cc85c6"/>
+                <option name="FOREGROUND" value="79c0ff"/>
+            </value>
+        </option>
+        <option name="JAVA_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff7b72"/>
             </value>
         </option>
         <option name="JAVA.TYPE_KEYWORD">
             <value>
-                <option name="FOREGROUND" value="47ccb1"/>
+                <option name="FOREGROUND" value="79c0ff"/>
             </value>
         </option>
         <option name="JS.CLASS">
@@ -632,7 +637,7 @@
         <option name="JS.FROM_KEYWORD">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
             </value>
         </option>
         <option name="JS.GLOBAL_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
@@ -1020,7 +1025,7 @@
         <option name="PY.CLASS_REFERENCE">
             <value>
                 <option name="FOREGROUND" value="47ccb1"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
             </value>
         </option>
         <option name="PY.Jupyter.CLASS_REFERENCE">
@@ -1043,7 +1048,7 @@
         <option name="PY.FUNCTION_CALL">
             <value>
                 <option name="FOREGROUND" value="e6e6aa"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
             </value>
         </option>
         <option name="PY.Jupyter.FUNCTION_CALL">
@@ -1055,7 +1060,7 @@
         <option name="PY.IMPORTS">
             <value>
                 <option name="FOREGROUND" value="47ccb1"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
             </value>
         </option>
         <option name="PY.Jupyter.IMPORTS">
@@ -1092,7 +1097,7 @@
         <option name="PY.SECONDARY_KEYWORD_WITH_BG">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
             </value>
         </option>
         <option name="PY.Jupyter.SECONDARY_KEYWORD_WITH_BG">
@@ -1121,7 +1126,7 @@
         </option>
         <option name="ReSharper.ASP_NET_RAZOR_CODE_BLOCK">
             <value>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>
@@ -1181,7 +1186,7 @@
         </option>
         <option name="STATIC_METHOD_ATTRIBUTES">
             <value>
-                <option name="FOREGROUND" value="ffc66d"/>
+                <option name="FOREGROUND" value="d2a8ff"/>
                 <option name="FONT_TYPE" value="2"/>
             </value>
         </option>
@@ -1209,7 +1214,7 @@
         <option name="TEXT">
             <value>
                 <option name="FOREGROUND" value="d4d4d4"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>
@@ -1228,7 +1233,7 @@
         <option name="TS.FROM_KEYWORD">
             <value>
                 <option name="FOREGROUND" value="cc85c6"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
             </value>
         </option>
         <option name="TS.MODULE_KEYWORD">
@@ -1271,14 +1276,14 @@
         <option name="XML_PROLOGUE">
             <value>
                 <option name="FOREGROUND" value="d4d4d4"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>
         <option name="XML_TAG">
             <value>
                 <option name="FOREGROUND" value="d4d4d4"/>
-                <option name="BACKGROUND" value="121314"/>
+                <option name="BACKGROUND" value="191a1c"/>
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>

--- a/src/main/resources/themes/vscode_2026_light.theme.json
+++ b/src/main/resources/themes/vscode_2026_light.theme.json
@@ -1,0 +1,177 @@
+{
+  "name": "VS Code 2026 Light",
+  "dark": false,
+  "author": "Dinesh Srinivasan",
+  "editorScheme": "/themes/vscode_2026_light.xml",
+  "ui": {
+    "*": {
+      "background": "#FAFAFD",
+      "foreground": "#202020",
+      "infoForeground": "#606060",
+      "selectionBackground": "#0069CC1A",
+      "lightSelectionBackground": "#0069CC1A",
+      "selectionInactiveBackground": "#DADADA99",
+      "selectionForeground": "#202020",
+      "selectionInactiveForeground": "#202020",
+      "hoverBackground": "#EDF0F5",
+      "disabledBackground": "#FAFAFD",
+      "inactiveBackground": "#FAFAFD",
+      "disabledForeground": "#BBBBBB",
+      "disabledText": "#BBBBBB",
+      "inactiveForeground": "#606060",
+      "acceleratorForeground": "#202020",
+      "acceleratorSelectionForeground": "#202020",
+      "borderColor": "#F0F1F2",
+      "disabledBorderColor": "#F0F1F2",
+      "focusColor": "#0069CCFF",
+      "focusedBorderColor": "#D8D8D8",
+      "separatorForeground": "#F0F1F2",
+      "separatorColor": "#F0F1F2",
+      "lineSeparatorColor": "#F0F1F2",
+      "modifiedItemForeground": "#667309"
+    },
+    "ActionButton": {
+      "hoverBackground": "#0063C1",
+      "hoverBorderColor": "#0063C1",
+      "pressedBackground": "#0069CC",
+      "pressedBorderColor": "#0069CC"
+    },
+    "Button": {
+      "startBackground": "#EAEAEA",
+      "endBackground": "#EAEAEA",
+      "startBorderColor": "#EEEEF1",
+      "endBorderColor": "#EEEEF1",
+      "shadowColor": "#00000000",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "#0069CC",
+        "endBackground": "#0069CC",
+        "startBorderColor": "#EEEEF1",
+        "endBorderColor": "#EEEEF1",
+        "focusedBorderColor": "#0069CC",
+        "focusColor": "#0069CCFF",
+        "shadowColor": "#00000000"
+      }
+    },
+    "Borders": {
+      "color": "#F0F1F2",
+      "ContrastBorderColor": "#E4E5E6"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "#FFFFFF",
+      "background": "#FFFFFF",
+      "modifiedItemForeground": "#0069CC",
+      "ArrowButton": {
+        "iconColor": "#606060",
+        "background": "#FFFFFF",
+        "disabledIconColor": "#BBBBBB",
+        "nonEditableBackground": "#FFFFFF"
+      }
+    },
+    "ComboPopup.border": "1,1,1,1,#E4E5E6",
+    "Component": {
+      "errorFocusColor": "#FDEDED",
+      "inactiveErrorFocusColor": "#FDEDED",
+      "warningFocusColor": "#FDF6E3",
+      "inactiveWarningFocusColor": "#FDF6E3",
+      "iconColor": "#606060",
+      "hoverIconColor": "#202020"
+    },
+    "Counter": {
+      "background": "#0069CC",
+      "foreground": "#FFFFFF"
+    },
+    "DebuggerPopup.borderColor": "#F0F1F2",
+    "DefaultTabs": {
+      "borderColor": "#F0F1F2",
+      "background": "#FAFAFD",
+      "inactiveUnderlineColor": "#F0F1F2",
+      "hoverBackground": "#FFFFFF",
+      "underlineColor": "#000000",
+      "underlineHeight": 2,
+      "underlinedTabBackground": "#FFFFFF"
+    },
+    "DragAndDrop": {
+      "areaForeground": "#202020",
+      "areaBackground": "#EDF0F5",
+      "borderColor": "#F0F1F2"
+    },
+    "Editor": {
+      "background": "#FFFFFF",
+      "SearchField.background": "#FAFAFD"
+    },
+    "EditorTabs": {
+      "tabInsets": true,
+      "underlinedTabBackground": "#FFFFFF",
+      "inactiveColoredFileBackground": "#FAFAFD"
+    },
+    "FileColor": {
+      "Yellow": "#FDF6E3",
+      "Green": "#E6F2FA",
+      "Blue": "#FAFAFD",
+      "Violet": "#FAFAFD",
+      "Orange": "#FFF4EB",
+      "Rose": "#FDEDED"
+    },
+    "Toolbar.Floating.borderColor": "#F0F1F2",
+    "ToolWindow.Header": {
+      "borderColor": "#F0F1F2"
+    },
+    "Notification": {
+      "background": "#FAFAFD",
+      "borderColor": "#F0F1F2"
+    },
+    "NotificationsToolwindow": {
+      "newNotification.background": "#EDF0F5"
+    },
+    "SearchMatch": {
+      "startBackground": "#0069CC40",
+      "endBackground": "#0069CC26"
+    },
+    "ToggleButton": {
+      "onBackground": "#0069CC"
+    },
+    "CompletionPopup": {
+      "matchForeground": "#0069CC"
+    },
+    "Popup": {
+      "Header": {
+        "activeBackground": "#FAFAFD",
+        "inactiveBackground": "#FFFFFF"
+      }
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedForeground": "#202020",
+        "selectedBackground": "#0069CC1A"
+      }
+    },
+    "ToolWindow": {
+      "background": "#FAFAFD",
+      "Header.borderColor": "#F0F1F2"
+    },
+    "Tree": {
+      "background": "#FAFAFD"
+    },
+    "Plugins": {
+      "borderColor": "#F0F1F2"
+    },
+    "WelcomeScreen": {
+      "background": "#FAFAFD",
+      "SidePanel.background": "#FAFAFD",
+      "borderColor": "#F0F1F2",
+      "Projects.background": "#FFFFFF",
+      "Projects.actions.background": "#0069CC"
+    },
+    "RunWidget": {
+      "foreground": "#202020",
+      "runningBackground": "#388A34",
+      "stopBackground": "#AD0707",
+      "hoverBackground": "#00000010",
+      "pressedBackground": "#00000018",
+      "iconColor": "#606060",
+      "runIconColor": "#388A34",
+      "runningIconColor": "#FFFFFF"
+    }
+  }
+}

--- a/src/main/resources/themes/vscode_2026_light.xml
+++ b/src/main/resources/themes/vscode_2026_light.xml
@@ -1,0 +1,1866 @@
+<scheme name="VSCode 2026 Light" version="142" parent_scheme="Default">
+    <metaInfo>
+        <property name="created">2023-08-13T00:59:37</property>
+        <property name="ide">idea</property>
+        <property name="ideVersion">2023.1.1.0.0</property>
+        <property name="modified">2023-08-13T00:59:51</property>
+        <property name="originalScheme">_@user_VSCode 2026 Light</property>
+    </metaInfo>
+    <colors>
+        <option name="CARET_COLOR" value="202020"/>
+        <option name="GUTTER_BACKGROUND" value="ffffff"/>
+        <option name="LINE_NUMBERS_COLOR" value="606060"/>
+        <option name="SELECTION_BACKGROUND" value="d4e2ff" />
+        <option name="SELECTION_FOREGROUND" value="202020" />
+    </colors>
+    <attributes>
+        <option name="BAD_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="ad0707"/>
+            </value>
+        </option>
+        <option name="BREAKPOINT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="ffc8c8"/>
+            </value>
+        </option>
+        <option name="BUILDOUT.KEY">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="BUILDOUT.KEY_VALUE_SEPARATOR">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="BUILDOUT.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="BUILDOUT.SECTION_NAME">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="BUILDOUT.VALUE">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.BAD_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.BOOLEAN">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.COLON">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="ee0000"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.EXISTENTIAL">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.FUNCTION_BINDING">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.FUNCTION_NAME">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.HEREDOC_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.HEREDOC_ID">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.HEREGEX_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="811f3f"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.HEREGEX_ID">
+            <value>
+                <option name="FOREGROUND" value="811f3f"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.JAVASCRIPT_ID">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.OBJECT_KEY">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.OPERATIONS">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.PROTOTYPE">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.REGULAR_EXPRESSION_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="811f3f"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.REGULAR_EXPRESSION_FLAG">
+            <value>
+                <option name="FOREGROUND" value="811f3f"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.REGULAR_EXPRESSION_ID">
+            <value>
+                <option name="FOREGROUND" value="811f3f"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.STRING_LITERAL">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.THIS">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="CONDITIONALLY_NOT_COMPILED">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="CONSOLE_BLUE_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_CYAN_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="b2b2"/>
+            </value>
+        </option>
+        <option name="CONSOLE_GRAY_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="595959"/>
+            </value>
+        </option>
+        <option name="CONSOLE_GREEN_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="CONSOLE_MAGENTA_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff00ff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_RED_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff0000"/>
+            </value>
+        </option>
+        <option name="CONSOLE_YELLOW_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ffcc00"/>
+            </value>
+        </option>
+        <option name="CSS.COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="CSS.FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="CSS.IDENT">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="CSS.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="CSS.PROPERTY_NAME">
+            <value>
+                <option name="FOREGROUND" value="0550ae"/>
+            </value>
+        </option>
+        <option name="CSS.TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="CSS.URL">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="CUSTOM_NUMBER_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="CUSTOM_STRING_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ee0000"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="Clojure Atom">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="Clojure Character">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="Clojure Keyword">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="Clojure Line comment">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="Clojure Literal">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="Clojure Numbers">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="Clojure Strings">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="DART_SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+            </value>
+        </option>
+        <option name="DART_SECONDARY_KEYWORD_WITH_BG">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+                <option name="BACKGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_ATTRIBUTE">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="DEFAULT_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="DEFAULT_CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="0550ae"/>
+            </value>
+        </option>
+        <option name="DEFAULT_CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="0550ae"/>
+            </value>
+        </option>
+        <option name="DEFAULT_COMMA" baseAttributes=""/>
+        <option name="DEFAULT_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="0550ae"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="6e7781"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT_TAG">
+            <value>
+                <option name="FOREGROUND" value="6e7781"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_MARKUP">
+            <value>
+                <option name="FOREGROUND" value="6e7781"/>
+            </value>
+        </option>
+        <option name="DEFAULT_ENTITY">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="8250df"/>
+            </value>
+        </option>
+        <option name="DEFAULT_FUNCTION_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="8250df"/>
+            </value>
+        </option>
+        <option name="DEFAULT_GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="953800"/>
+            </value>
+        </option>
+        <option name="DEFAULT_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="1f2328"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INSTANCE_FIELD">
+            <value>
+                <option name="FOREGROUND" value="0550ae"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INSTANCE_METHOD">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INTERFACE_NAME">
+            <value>
+                <option name="FOREGROUND" value="0550ae"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ad0707"/>
+            </value>
+        </option>
+        <option name="DEFAULT_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cf222e"/>
+            </value>
+        </option>
+        <option name="DEFAULT_LABEL" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="DEFAULT_LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="6e7781"/>
+            </value>
+        </option>
+        <option name="DEFAULT_LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="953800"/>
+            </value>
+        </option>
+        <option name="DEFAULT_METADATA" baseAttributes="TEXT"/>
+        <option name="DEFAULT_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="DEFAULT_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="DEFAULT_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="953800"/>
+            </value>
+        </option>
+        <option name="DEFAULT_PREDEFINED_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+            </value>
+        </option>
+        <option name="DEFAULT_SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_SECONDARY_KEYWORD_WITH_BG">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+                <option name="BACKGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="DEFAULT_SEMICOLON" baseAttributes=""/>
+        <option name="DEFAULT_STATIC_FIELD">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_STATIC_METHOD">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="DEFAULT_STRING">
+            <value>
+                <option name="FOREGROUND" value="0a3069"/>
+            </value>
+        </option>
+        <option name="DEFAULT_TAG">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR" baseAttributes="TEXT"/>
+        <option name="DEFAULT_VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ee0000"/>
+            </value>
+        </option>
+        <option name="DJANGO_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="DJANGO_FILTER">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="DJANGO_ID">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="DJANGO_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="DJANGO_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="DJANGO_STRING_LITERAL">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="DJANGO_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="ERRORS_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="ff0000"/>
+                <option name="ERROR_STRIPE_COLOR" value="ff0000"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+                <option name="BACKGROUND" value="e9e9e9"/>
+                <option name="FONT_TYPE" value="2"/>
+                <option name="EFFECT_COLOR" value="ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="JSON.IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="202020"/>
+            </value>
+        </option>
+        <option name="JSON.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="cf222e"/>
+            </value>
+        </option>
+        <option name="JSON.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="0550ae"/>
+            </value>
+        </option>
+        <option name="JSON.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="953800"/>
+            </value>
+        </option>
+        <option name="JSON.PROPERTY_KEY">
+            <value>
+                <option name="FOREGROUND" value="116329"/>
+            </value>
+        </option>
+        <option name="JSON.STRING">
+            <value>
+                <option name="FOREGROUND" value="0a3069"/>
+            </value>
+        </option>
+        <option name="JSON.VALID_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="116329"/>
+            </value>
+        </option>
+        <option name="JSON.INVALID_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ad0707"/>
+                <option name="EFFECT_COLOR" value="ad0707"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="First symbol in list">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="GENERIC_SERVER_ERROR_OR_WARNING">
+            <value>
+                <option name="EFFECT_COLOR" value="f49810"/>
+                <option name="ERROR_STRIPE_COLOR" value="f49810"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="GHERKIN_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="GHERKIN_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="GHERKIN_OUTLINE_PARAMETER_SUBSTITUTION">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="GHERKIN_PYSTRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="GHERKIN_REGEXP_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="GHERKIN_TABLE_HEADER_CELL">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="GHERKIN_TABLE_PIPE">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+        <option name="GHERKIN_TAG">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="GO_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="GO_EXPORTED_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="GO_EXPORTED_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="GO_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="GO_LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="GO_LOCAL_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="GO_LOCAL_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="GO_PACKAGE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="GQL_ID">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="GQL_INT_LITERAL">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="GQL_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="GQL_STRING_LITERAL">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="HAML_CLASS">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="HAML_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="HAML_ID">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="HAML_STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="HAML_STRING_INTERPOLATED">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="HAML_TAG">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="HAML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="HTML_ATTRIBUTE_NAME">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="HTML_ATTRIBUTE_VALUE">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="HTML_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="HTML_TAG">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="116329"/>
+            </value>
+        </option>
+        <option name="HYPERLINK_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+                <option name="FONT_TYPE" value="2"/>
+                <option name="EFFECT_COLOR" value="ff"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="e4e4ff"/>
+                <option name="ERROR_STRIPE_COLOR" value="ccccff"/>
+            </value>
+        </option>
+        <option name="INFO_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="cccccc"/>
+                <option name="ERROR_STRIPE_COLOR" value="ffffcc"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="IVAR">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="JADE_FILE_PATH">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="JADE_STATEMENTS">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="JAVA.SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+            </value>
+        </option>
+        <option name="JAVA_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="JAVA_DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="JAVA_DOC_MARKUP">
+            <value>
+                <option name="BACKGROUND" value="e2ffe2"/>
+            </value>
+        </option>
+        <option name="JAVA_DOC_TAG">
+            <value>
+                <option name="FONT_TYPE" value="1"/>
+                <option name="EFFECT_COLOR" value="808080"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="JAVA_INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="JAVA_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="JAVA_LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="JAVA_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="JAVA_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="JAVA_STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="JAVA_VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ee0000"/>
+            </value>
+        </option>
+        <option name="JS.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="277f99"/>
+            </value>
+        </option>
+        <option name="JS.FROM_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+            </value>
+        </option>
+        <option name="JS.GLOBAL_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
+        <option name="JS.GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JS.IMPORT_SPECIFIER">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="JS.INSTANCE_MEMBER_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="JS.LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="JS.NULL_UNDEFINED">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="JS.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="JS.REGEXP">
+            <value>
+                <option name="FOREGROUND" value="811f3f"/>
+            </value>
+        </option>
+        <option name="JS.SECONDARY_KEYWORDS">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+            </value>
+        </option>
+        <option name="LABEL">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="LESS_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="MACRONAME">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="NG.BANANA_BINDING_ATTR_NAME">
+            <value>
+                <option name="FOREGROUND" value="e50101"/>
+            </value>
+        </option>
+        <option name="NG.EVENT_BINDING_ATTR_NAME">
+            <value>
+                <option name="FOREGROUND" value="e50101"/>
+            </value>
+        </option>
+        <option name="NG.PROPERTY_BINDING_ATTR_NAME">
+            <value>
+                <option name="FOREGROUND" value="e50101"/>
+            </value>
+        </option>
+        <option name="NG.TEMPLATE_BINDINGS_ATTR_NAME">
+            <value>
+                <option name="FOREGROUND" value="e50101"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="OC.BADCHARACTER">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="OC.BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="OC.CPP_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="OC.DIRECTIVE">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="OC.EXTERN_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="OC.GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="OC.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="OC.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="OC.LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="OC.MESSAGE_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="OC.METHOD_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="OC.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="OC.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="OC.PROPERTY">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="OC.SELFSUPERTHIS">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="OC.STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="OC_FORMAT_TOKEN">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="PHP_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="PHP_VAR">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="PROTOCOL_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+            </value>
+        </option>
+        <option name="PUPPET_BAD_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="PUPPET_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="PUPPET_CLASS">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+            </value>
+        </option>
+        <option name="PUPPET_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="ee0000"/>
+            </value>
+        </option>
+        <option name="PUPPET_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+        <option name="PUPPET_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="PUPPET_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="PUPPET_REGEX">
+            <value>
+                <option name="FOREGROUND" value="811f3f"/>
+            </value>
+        </option>
+        <option name="PUPPET_SQ_STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="PUPPET_STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="PUPPET_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="PUPPET_VARIABLE_INTERPOLATION">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="PY.BUILTIN_NAME">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+            </value>
+        </option>
+        <option name="PY.CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+                <option name="BACKGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="PY.Jupyter.CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+                <option name="BACKGROUND" value="F7F8FA"/>
+            </value>
+        </option>
+        <option name="PY.CLASS_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+            </value>
+        </option>
+        <option name="PY.DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="PY.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="PY.DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="PY.FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+                <option name="BACKGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="PY.Jupyter.FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+                <option name="BACKGROUND" value="F7F8FA"/>
+            </value>
+        </option>
+        <option name="PY.FUNC_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="PY.IMPORTS">
+            <value>
+                <option name="FOREGROUND" value="277f99"/>
+                <option name="BACKGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="PY.Jupyter.IMPORTS">
+            <value>
+                <option name="FOREGROUND" value="277f99"/>
+                <option name="BACKGROUND" value="F7F8FA"/>
+            </value>
+        </option>
+        <option name="PY.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="PY.KEYWORD_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="PY.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="PY.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="PY.OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="PY.PREDEFINED_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="PY.PREDEFINED_USAGE">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="PY.SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+            </value>
+        </option>
+        <option name="PY.SECONDARY_KEYWORD_WITH_BG">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+                <option name="BACKGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="PY.Jupyter.SECONDARY_KEYWORD_WITH_BG">
+            <value>
+                <option name="FOREGROUND" value="bf3be2"/>
+                <option name="BACKGROUND" value="F7F8FA"/>
+            </value>
+        </option>
+        <option name="PY.STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="PY.VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ee0000"/>
+            </value>
+        </option>
+        <option name="PY.SELF_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="REST.BOLD">
+            <value>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="REST.EXPLICIT">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="REST.FIELD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="REST.FIXED">
+            <value>
+                <option name="BACKGROUND" value="d9d9f0"/>
+            </value>
+        </option>
+        <option name="REST.INLINE">
+            <value>
+                <option name="BACKGROUND" value="edfced"/>
+            </value>
+        </option>
+        <option name="REST.INTERPRETED">
+            <value>
+                <option name="BACKGROUND" value="cadaba"/>
+            </value>
+        </option>
+        <option name="REST.ITALIC">
+            <value>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="REST.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="REST.REF.NAME">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="REST.SECTION.HEADER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="RHTML_COMMENT_ID">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_END_ID">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_START_ID">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="RHTML_OMIT_NEW_LINE_ID">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTING_BACKGROUND_ID">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_END_ID">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_START_ID">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="RUBY_BAD_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="RUBY_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+            </value>
+        </option>
+        <option name="RUBY_CVAR">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="RUBY_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="ee0000"/>
+            </value>
+        </option>
+        <option name="RUBY_EXPR_IN_STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="RUBY_GVAR">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="RUBY_HASH_ASSOC">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_ID">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="RUBY_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="RUBY_INTERPOLATED_STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="RUBY_IVAR">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="RUBY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="RUBY_LINE_CONTINUATION">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="RUBY_LOCAL_VAR_ID">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="RUBY_METHOD_NAME">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="RUBY_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="RUBY_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="RUBY_PARAMDEF_CALL">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="RUBY_PARAMETER_ID">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="RUBY_REGEXP">
+            <value>
+                <option name="FOREGROUND" value="811f3f"/>
+            </value>
+        </option>
+        <option name="RUBY_SPECIFIC_CALL">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="RUBY_STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="RUBY_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="RUBY_WORDS">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="SASS_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="SASS_DEFAULT">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+        <option name="SASS_EXTEND">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+        <option name="SASS_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="451a5"/>
+            </value>
+        </option>
+        <option name="SASS_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="SASS_IMPORTANT">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+        <option name="SASS_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+        <option name="SASS_MIXIN">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="SASS_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="98658"/>
+            </value>
+        </option>
+        <option name="SASS_PROPERTY_NAME">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="SASS_PROPERTY_VALUE">
+            <value>
+                <option name="FOREGROUND" value="451a5"/>
+            </value>
+        </option>
+        <option name="SASS_STRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="SASS_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="SASS_URL">
+            <value>
+                <option name="FOREGROUND" value="451a5"/>
+            </value>
+        </option>
+        <option name="SASS_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="ccccff"/>
+            </value>
+        </option>
+        <option name="SLIM_BAD_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="cd3131"/>
+            </value>
+        </option>
+        <option name="SLIM_CLASS">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="SLIM_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="SLIM_DOCTYPE_KWD">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="SLIM_FILTER">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="SLIM_ID">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="SLIM_INTERPOLATION">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="SLIM_STRING_INTERPOLATED">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="SLIM_TAG">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="SLIM_TAG_ATTR_KEY">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="SLIM_TAG_START">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="SPY-JS.EXCEPTION">
+            <value>
+                <option name="BACKGROUND" value="ffcccc"/>
+                <option name="EFFECT_COLOR" value="3b3b3b"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="SPY-JS.FUNCTION_SCOPE">
+            <value>
+                <option name="BACKGROUND" value="fffff0"/>
+                <option name="EFFECT_COLOR" value="3b3b3b"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="SPY-JS.PATH_LEVEL_ONE">
+            <value>
+                <option name="BACKGROUND" value="e2ffe2"/>
+                <option name="EFFECT_COLOR" value="3b3b3b"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="SPY-JS.PATH_LEVEL_TWO">
+            <value>
+                <option name="EFFECT_COLOR" value="3b3b3b"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="SPY-JS.PROGRAM_SCOPE">
+            <value>
+                <option name="BACKGROUND" value="ffffff"/>
+                <option name="EFFECT_COLOR" value="3b3b3b"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="SPY-JS.VALUE_HINT" baseAttributes=""/>
+        <option name="STATIC_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="660e7a"/>
+                <option name="FONT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="STATIC_METHOD_ATTRIBUTES">
+            <value>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="TAG_ATTR_KEY">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="TEXT">
+            <value>
+                <option name="FOREGROUND" value="202020"/>
+                <option name="BACKGROUND" value="ffffff"/>
+            </value>
+        </option>
+        <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="ffff00"/>
+                <option name="ERROR_STRIPE_COLOR" value="ff00"/>
+            </value>
+        </option>
+        <option name="TODO_DEFAULT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+                <option name="FONT_TYPE" value="3"/>
+                <option name="ERROR_STRIPE_COLOR" value="ff"/>
+            </value>
+        </option>
+        <option name="TYPEDEF">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="WARNING_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="be9117"/>
+                <option name="ERROR_STRIPE_COLOR" value="be9117"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="ffe4ff"/>
+                <option name="ERROR_STRIPE_COLOR" value="ffcdff"/>
+            </value>
+        </option>
+        <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="ffcdff"/>
+            </value>
+        </option>
+        <option name="XML_ATTRIBUTE_NAME">
+            <value>
+                <option name="FOREGROUND" value="e50000"/>
+            </value>
+        </option>
+        <option name="XML_ATTRIBUTE_VALUE">
+            <value>
+                <option name="FOREGROUND" value="0000ff"/>
+            </value>
+        </option>
+        <option name="XML_ENTITY_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="XML_TAG">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="XML_TAG_DATA">
+            <value>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="XML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="116329"/>
+            </value>
+        </option>
+        <option name="YAML_ANCHOR">
+            <value>
+                <option name="FOREGROUND" value="1080" />
+            </value>
+        </option>
+        <option name="YAML_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="8000"/>
+            </value>
+        </option>
+        <option name="YAML_SCALAR_DSTRING">
+            <value>
+                <option name="FOREGROUND" value="a31515"/>
+            </value>
+        </option>
+        <option name="YAML_SCALAR_KEY">
+            <value>
+                <option name="FOREGROUND" value="800000"/>
+            </value>
+        </option>
+        <option name="YAML_SCALAR_LIST">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="YAML_SCALAR_STRING">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="YAML_SCALAR_VALUE">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="YAML_SIGN">
+            <value>
+                <option name="FOREGROUND" value="0"/>
+            </value>
+        </option>
+        <option name="YAML_TEXT">
+            <value>
+                <option name="FOREGROUND" value="ff" />
+            </value>
+        </option>
+
+        <option name="HCL.BLOCK_FIRST_TYPE_KEY">
+            <value>
+                <option name="FOREGROUND" value="267f99"/>
+            </value>
+        </option>
+        <option name="HCL.BLOCK_NAME_KEY">
+            <value>
+                <option name="FOREGROUND" value="70c1"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="HCL.BLOCK_SECOND_TYPE_KEY">
+            <value>
+                <option name="FOREGROUND" value="70c1"/>
+                <option name="EFFECT_COLOR" value="70c1"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="HCL.FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="795e26"/>
+            </value>
+        </option>
+        <option name="HCL.IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="HCL.SECONDARY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+        <option name="HCL.TYPE">
+            <value>
+                <option name="FOREGROUND" value="af00db"/>
+            </value>
+        </option>
+
+        <option name="TIL.BRACES">
+            <value>
+                <option name="FOREGROUND" value="ff"/>
+            </value>
+        </option>
+        <option name="TIL.PREDEFINED_SCOPE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+            </value>
+        </option>
+        <option name="TIL.RESOURCE_INSTANCE_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="TIL.RESOURCE_TYPE_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="1080"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+    </attributes>
+</scheme>


### PR DESCRIPTION
Tweaked the initial version. Looks good to me, no big problems.